### PR TITLE
Se agrega validación de CC, CE y NIT para Colombia

### DIFF
--- a/lib/bali.ex
+++ b/lib/bali.ex
@@ -6,6 +6,7 @@ defmodule Bali do
 
   alias Validators.Portugal
   alias Validators.Spain
+  alias Validators.Colombia
 
   @doc """
   Valida el documento según el país y tipo
@@ -19,6 +20,11 @@ defmodule Bali do
   def validate(:es, document_type, value) do
     clean_value = clean_string(value)
     Spain.valid(document_type, clean_value)
+  end
+
+  def validate(:co, document_type, value) do
+    clean_value = clean_string(value)
+    Colombia.valid(document_type, clean_value)
   end
 
   def validate(country, _document_type, _value) do

--- a/lib/validators/colombia.ex
+++ b/lib/validators/colombia.ex
@@ -1,0 +1,51 @@
+defmodule Validators.Colombia do
+  @moduledoc """
+  Validador para los identificadores personales y fiscales de Colombia
+  """
+
+  @doc """
+  Valida el formato de la CC(Cédula de Ciudadania)
+  Su estructura es un bloque de entre 6 y 10 dígitos
+  """
+  @spec valid(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def valid(:cc, value) do
+    if Regex.match?(~r/^\d{6,10}$/, value) do
+      {:ok, value}
+    else
+      {:error, "CC inválida"}
+    end
+  end
+
+  @doc """
+  Valida el formato de la CE(Cédula de Extranjería)
+  Su estructura es un bloque de 6 dígitos
+  """
+  @spec valid(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def valid(:ce, value) do
+    if Regex.match?(~r/^\d{6}$/, value) do
+      {:ok, value}
+    else
+      {:error, "CE inválida"}
+    end
+  end
+
+  @doc """
+  Valida el formato del NIT(Número de Identificación Tributario)
+  Su estructura es un bloque de entre 6 y 10 dígitos, un guión y un dígito
+  """
+  @spec valid(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def valid(:nit, value) do
+    if Regex.match?(~r/^\d{6,10}-\d{1}$/, value) do
+      {:ok, value}
+    else
+      {:error, "NIT inválido"}
+    end
+  end
+
+  @doc """
+   Validación cuando el nombre del identificador y el valor son incorrectos
+  """
+  def valid(_, _) do
+    {:error, "Tipo de documento inválido"}
+  end
+end

--- a/test/bali_test.exs
+++ b/test/bali_test.exs
@@ -42,6 +42,36 @@ defmodule BaliTest do
     assert {:error, "NIE inválido"} == Bali.validate(:es, :nie, value)
   end
 
+  test "Puedo validar el identificador CC(Cédula de Ciudadania) de Colombia exitosamente" do
+    value = "1234567891"
+    assert {:ok, value} == Bali.validate(:co, :cc, value)
+  end
+
+  test "Puedo validar que el identificador CC(Cédula de Ciudadania) de Colombia no es correcto" do
+    value = "12345678912"
+    assert {:error, "CC inválida"} == Bali.validate(:co, :cc, value)
+  end
+
+  test "Puedo validar el identificador CE(Cédula de Extranjería) de Colombia exitosamente" do
+    value = "123456"
+    assert {:ok, value} == Bali.validate(:co, :ce, value)
+  end
+
+  test "Puedo validar que el identificador CE(Cédula de Extranjería) de Colombia no es correcto" do
+    value = "1234567"
+    assert {:error, "CE inválida"} == Bali.validate(:co, :ce, value)
+  end
+
+  test "Puedo validar el identificador NIT(Número de Identificación Tributario) de Colombia exitosamente" do
+    value = "123456-1"
+    assert {:ok, value} == Bali.validate(:co, :nit, value)
+  end
+
+  test "Puedo verificar que el identificador NIT(Número de Identificación Tributario) de Colombia no es correcto" do
+    value = "123456-12"
+    assert {:error, "NIT inválido"} == Bali.validate(:co, :nit, value)
+  end
+
   test "Puedo validar mandar un mensaje de error, si el país no es soportado" do
     assert {:error, "País sk no soportado"} ==
              Bali.validate(:sk, :dni, "12345678A")

--- a/test/validators/colombia_test.exs
+++ b/test/validators/colombia_test.exs
@@ -1,0 +1,60 @@
+defmodule Validators.ColombiaTest do
+  use ExUnit.Case
+
+  alias Validators.Colombia
+
+  test "Puedo validar que la CC es correcta a 6 dígitos" do
+    value = "123456"
+    assert {:ok, value} == Colombia.valid(:cc, value)
+  end
+
+  test "Puedo validar que la CC es correcta a 7 dígitos" do
+    value = "1234567"
+    assert {:ok, value} == Colombia.valid(:cc, value)
+  end
+
+  test "Puedo validar que la CC es correcta a 8 dígitos" do
+    value = "12345678"
+    assert {:ok, value} == Colombia.valid(:cc, value)
+  end
+
+  test "Puedo validar que la CC es correcta a 9 dígitos" do
+    value = "123456789"
+    assert {:ok, value} == Colombia.valid(:cc, value)
+  end
+
+  test "Puedo validar que la CC es correcta a 10 dígitos" do
+    value = "1234567891"
+    assert {:ok, value} == Colombia.valid(:cc, value)
+  end
+
+  test "Puedo verificar que la CC es inválida a 11 dígitos" do
+    value = "12345678912"
+    assert {:error, "CC inválida"} == Colombia.valid(:cc, value)
+  end
+
+  test "Puedo validar que la CE es correcta a 6 dígitos" do
+    value = "123456"
+    assert {:ok, value} == Colombia.valid(:ce, value)
+  end
+
+  test "Puedo verificar que la CE es inválida a 7 dígitos" do
+    value = "1234567"
+    assert {:error, "CE inválida"} == Colombia.valid(:ce, value)
+  end
+
+  test "Puedo validar que el NIT es correcto a 6 digitos y un dígito verificador" do
+    value = "123456-1"
+    assert {:ok, value} == Colombia.valid(:nit, value)
+  end
+
+  test "Puedo verificar que el NIT es inválido a 6 digitos y dos dígitos extra" do
+    value = "123456-12"
+    assert {:error, "NIT inválido"} == Colombia.valid(:nit, value)
+  end
+
+  test "Puedo validar si me mandan el parámetro de identificación y valor incorrectos se envia un mensaje de error" do
+    assert {:error, "Tipo de documento inválido"} ==
+             Colombia.valid(:ab, "12345678A")
+  end
+end


### PR DESCRIPTION
### ¿Qué hice?

- Agrega al módulo principal, el validador de identificadores para Colombia 
- Genere el módulo para agregar las validaciones para Colombia en este caso el CC(Cédula de Ciudadania), la CE(Cédula de Extranjería) y el NIT(Número de Identificación Tributario) 
- Issue relacionado [750](https://github.com/resuelve/platform/issues/750)