### PR TITLE
Se agrega validación de NIF para Italia

### DIFF
--- a/lib/bali.ex
+++ b/lib/bali.ex
@@ -8,6 +8,7 @@ defmodule Bali do
   alias Validators.Spain
   alias Validators.Colombia
   alias Validators.Mexico
+  alias Validators.Italy
 
   @doc """
   Limpia la cadena previo a realizar la validación del documento
@@ -34,6 +35,10 @@ defmodule Bali do
 
   defp do_validate(:mx, document_type, value) do
     Mexico.valid(document_type, value)
+  end
+
+  defp do_validate(:it, document_type, value) do
+    Italy.valid(document_type, value)
   end
 
   defp do_validate(country, _document_type, _value) do

--- a/lib/validators/italy.ex
+++ b/lib/validators/italy.ex
@@ -1,0 +1,35 @@
+defmodule Validators.Italy do
+  @moduledoc """
+  Validador para los identificadores personales y fiscales de Italia
+  """
+
+  @doc """
+    Valida el formato del NIF(Número de identificación fiscal)
+    Su estructura es la siguiente:
+        - Se utilizan las tres primeras consonantes del apellido
+        - Se utilizan las tres primeras consonantes del nombre
+        - Año de nacimiento (dos dígitos)
+        - Mes de nacimiento (una letra)
+        - Cumpleaños y sexo (2 dígitos)
+        - Ciudad de nacimiento (4 caracteres alfanuméricos)
+        - Caracter de control (una letra)
+  """
+  @spec valid(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def valid(:nif, value) do
+    if Regex.match?(
+         ~r/^([A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST]{1}[0-9LMNPQRSTUV]{2}[A-Z]{1}[0-9LMNPQRSTUV]{3}[A-Z]{1})$|([0-9]{11})$/,
+         value
+       ) do
+      {:ok, value}
+    else
+      {:error, "NIF inválido"}
+    end
+  end
+
+  @doc """
+   Validación cuando el nombre del identificador y el valor son incorrectos
+  """
+  def valid(_, _) do
+    {:error, "Tipo de documento inválido"}
+  end
+end

--- a/test/bali_test.exs
+++ b/test/bali_test.exs
@@ -92,6 +92,16 @@ defmodule BaliTest do
     assert {:error, "CURP inválido"} == Bali.validate(:mx, :curp, value)
   end
 
+  test "Puedo validar el identificador NIF(Numero de identificacion fiscal) de Italia exitosamente" do
+    value = "VRDGPP13R10B293P"
+    assert {:ok, value} == Bali.validate(:it, :nif, value)
+  end
+
+  test "Puedo verificar que el identificador NIF(Numero de identificacion fiscal) de Italia no es correcto" do
+    value = "VRDGPP13R10B29BP"
+    assert {:error, "NIF inválido"} == Bali.validate(:it, :nif, value)
+  end
+
   test "Puedo validar mandar un mensaje de error, si el país no es soportado" do
     assert {:error, "País sk no soportado"} ==
              Bali.validate(:sk, :dni, "12345678A")

--- a/test/validators/italy_test.exs
+++ b/test/validators/italy_test.exs
@@ -1,0 +1,22 @@
+defmodule Validators.ItalyTest do
+  use ExUnit.Case
+
+  use ExUnit.Case
+
+  alias Validators.Italy
+
+  test "Puedo validar el NIF(Número de identificación fiscal) para Italia" do
+    value = "VRDGPP13R10B293P"
+    assert {:ok, value} == Italy.valid(:nif, value)
+  end
+
+  test "Puedo validar que el NIF(Número de identificación fiscal) para Italia no es correcto" do
+    value = "VRDGPP13R10B29BP"
+    assert {:error, "NIF inválido"} == Italy.valid(:nif, value)
+  end
+
+  test "Puedo validar si me mandan el parámetro de identificación y valor incorrectos se envia un mensaje de error" do
+    assert {:error, "Tipo de documento inválido"} ==
+             Italy.valid(:sk, "12345678A")
+  end
+end


### PR DESCRIPTION
### ¿Qué hice?

- Agrega al módulo principal, el validador de identificadores para Italia 
- Generé el módulo para agregar la validación del NIF(Número de Identificación Fiscal) para Italia
- Issue relacionado [750](https://github.com/resuelve/platform/issues/750)