### PR TITLE
Validación para documentos personales y fiscales 

### DIFF
--- a/lib/bali.ex
+++ b/lib/bali.ex
@@ -22,7 +22,8 @@ defmodule Bali do
     mx: ["curp"],
     co: ["cc", "ce"],
     es: ["dni", "nie"],
-    it: ["cie"]
+    it: ["cie"],
+    pt: ["nif"]
   }
 
   @doc """
@@ -101,23 +102,23 @@ defmodule Bali do
 
   @spec do_validate(atom, atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
   defp do_validate(:pt, document_type, value) do
-    Portugal.valid(document_type, value)
+    Portugal.validate(document_type, value)
   end
 
   defp do_validate(:es, document_type, value) do
-    Spain.valid(document_type, value)
+    Spain.validate(document_type, value)
   end
 
   defp do_validate(:co, document_type, value) do
-    Colombia.valid(document_type, value)
+    Colombia.validate(document_type, value)
   end
 
   defp do_validate(:mx, document_type, value) do
-    Mexico.valid(document_type, value)
+    Mexico.validate(document_type, value)
   end
 
   defp do_validate(:it, document_type, value) do
-    Italy.valid(document_type, value)
+    Italy.validate(document_type, value)
   end
 
   defp do_validate(country, _document_type, _value) do
@@ -141,8 +142,9 @@ defmodule Bali do
   Revisa si el tipo documento fiscal recibido se encuentra en la lista de documentos
   válidos y verifica que su valor sea correcto
   """
-  @spec validate_fiscal(atom, atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def validate_fiscal(country, document_type, value) do
+  @spec validate_fiscal_document(atom, atom, String.t()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def validate_fiscal_document(country, document_type, value) do
     case Map.get(@tax_documents, country) do
       nil ->
         {:error, "País no soportado"}
@@ -160,8 +162,9 @@ defmodule Bali do
   Revisa si el tipo documento personal recibido se encuentra en la lista de documentos
   válidos y verifica que su valor sea correcto
   """
-  @spec validate_personal(atom, atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def validate_personal(country, document_type, value) do
+  @spec validate_personal_document(atom, atom, String.t()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  def validate_personal_document(country, document_type, value) do
     case Map.get(@personal_documents, country) do
       nil ->
         {:error, "País no soportado"}

--- a/lib/bali.ex
+++ b/lib/bali.ex
@@ -10,6 +10,21 @@ defmodule Bali do
   alias Validators.Mexico
   alias Validators.Italy
 
+  @tax_documents %{
+    mx: ["rfc"],
+    co: ["nit"],
+    es: ["nif"],
+    it: ["nif"],
+    pt: ["nif"]
+  }
+
+  @personal_documents %{
+    mx: ["curp"],
+    co: ["cc", "ce"],
+    es: ["dni", "nie"],
+    it: ["cie"]
+  }
+
   @doc """
   Valida el identificador personal o fiscal segun el país(mx,co,es,pt,it) y tipo 
 
@@ -120,5 +135,43 @@ defmodule Bali do
   """
   def get_document_types do
     ["DNI", "NIE", "NIF", "RFC", "CURP", "CC", "CE", "NIT"]
+  end
+
+  @doc """
+  Revisa si el tipo documento fiscal recibido se encuentra en la lista de documentos
+  válidos y verifica que su valor sea correcto
+  """
+  @spec validate_fiscal(atom, atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def validate_fiscal(country, document_type, value) do
+    case Map.get(@tax_documents, country) do
+      nil ->
+        {:error, "País no soportado"}
+
+      tax_documents_per_country ->
+        if Enum.member?(tax_documents_per_country, Atom.to_string(document_type)) do
+          do_validate(country, document_type, value)
+        else
+          {:error, "Documento fiscal inválido para el país: #{country}"}
+        end
+    end
+  end
+
+  @doc """
+  Revisa si el tipo documento personal recibido se encuentra en la lista de documentos
+  válidos y verifica que su valor sea correcto
+  """
+  @spec validate_personal(atom, atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def validate_personal(country, document_type, value) do
+    case Map.get(@personal_documents, country) do
+      nil ->
+        {:error, "País no soportado"}
+
+      personal_documents_per_country ->
+        if Enum.member?(personal_documents_per_country, Atom.to_string(document_type)) do
+          do_validate(country, document_type, value)
+        else
+          {:error, "Documento personal inválido para el país: #{country}"}
+        end
+    end
   end
 end

--- a/lib/validators/colombia.ex
+++ b/lib/validators/colombia.ex
@@ -12,22 +12,22 @@ defmodule Validators.Colombia do
 
   ```elixir
 
-    iex> Validators.Colombia.validate(:cc, "1234567891")
+    iex> Validators.Colombia.valid(:cc, "1234567891")
     {:ok, "1234567891"}
 
-    iex> Validators.Colombia.validate(:cc, "12345678912")
+    iex> Validators.Colombia.valid(:cc, "12345678912")
     {:error, "CC inválida"}
 
-    iex> Validators.Colombia.validate(:ce, "123456")
+    iex> Validators.Colombia.valid(:ce, "123456")
     {:ok, "123456"}
 
-    iex> Validators.Colombia.validate(:ce, "1234567")
+    iex> Validators.Colombia.valid(:ce, "1234567")
     {:error, "CE inválida"}    
 
-    iex> Validators.Colombia.validate(:nit, "123456-1")
+    iex> Validators.Colombia.valid(:nit, "123456-1")
     {:ok, "123456-1"}
 
-    iex> Validators.Colombia.validate(:nit, "123456-12")
+    iex> Validators.Colombia.valid(:nit, "123456-12")
     {:error, "NIT inválido"}    
 
   ```      

--- a/lib/validators/colombia.ex
+++ b/lib/validators/colombia.ex
@@ -12,28 +12,28 @@ defmodule Validators.Colombia do
 
   ```elixir
 
-    iex> Validators.Colombia.valid(:cc, "1234567891")
+    iex> Validators.Colombia.validate(:cc, "1234567891")
     {:ok, "1234567891"}
 
-    iex> Validators.Colombia.valid(:cc, "12345678912")
+    iex> Validators.Colombia.validate(:cc, "12345678912")
     {:error, "CC inválida"}
 
-    iex> Validators.Colombia.valid(:ce, "123456")
+    iex> Validators.Colombia.validate(:ce, "123456")
     {:ok, "123456"}
 
-    iex> Validators.Colombia.valid(:ce, "1234567")
+    iex> Validators.Colombia.validate(:ce, "1234567")
     {:error, "CE inválida"}    
 
-    iex> Validators.Colombia.valid(:nit, "123456-1")
+    iex> Validators.Colombia.validate(:nit, "123456-1")
     {:ok, "123456-1"}
 
-    iex> Validators.Colombia.valid(:nit, "123456-12")
+    iex> Validators.Colombia.validate(:nit, "123456-12")
     {:error, "NIT inválido"}    
 
   ```      
   """
-  @spec valid(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def valid(:cc, value) do
+  @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def validate(:cc, value) do
     if Regex.match?(cc(), value) do
       {:ok, value}
     else
@@ -41,7 +41,7 @@ defmodule Validators.Colombia do
     end
   end
 
-  def valid(:ce, value) do
+  def validate(:ce, value) do
     if Regex.match?(ce(), value) do
       {:ok, value}
     else
@@ -49,7 +49,7 @@ defmodule Validators.Colombia do
     end
   end
 
-  def valid(:nit, value) do
+  def validate(:nit, value) do
     if Regex.match?(nit(), value) do
       {:ok, value}
     else
@@ -57,7 +57,7 @@ defmodule Validators.Colombia do
     end
   end
 
-  def valid(_, _) do
+  def validate(_, _) do
     {:error, "Tipo de documento inválido"}
   end
 

--- a/lib/validators/italy.ex
+++ b/lib/validators/italy.ex
@@ -12,22 +12,22 @@ defmodule Validators.Italy do
 
   ```elixir
 
-    iex> Validators.Italy.valid(:nif, "VRDGPP13R10B293P")
+    iex> Validators.Italy.validate(:nif, "VRDGPP13R10B293P")
     {:ok, "VRDGPP13R10B293P"}
 
-    iex> Validators.Italy.valid(:nif, "VRDGPP13R10B29BP")
+    iex> Validators.Italy.validate(:nif, "VRDGPP13R10B29BP")
     {:error, "NIF inválido"}
 
-    iex> Validators.Italy.valid(:cie, "CA00000AA")
+    iex> Validators.Italy.validate(:cie, "CA00000AA")
     {:ok, "CA00000AA"}
 
-    iex> Validators.Italy.valid(:cie, "BA00000AA")
+    iex> Validators.Italy.validate(:cie, "BA00000AA")
     {:error, "CIE inválido"}
 
   ```    
   """
-  @spec valid(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def valid(:nif, value) do
+  @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def validate(:nif, value) do
     if Regex.match?(nif(), value) do
       {:ok, value}
     else
@@ -35,8 +35,8 @@ defmodule Validators.Italy do
     end
   end
 
-  @spec valid(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def valid(:cie, value) do
+  @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def validate(:cie, value) do
     if Regex.match?(cie(), value) do
       {:ok, value}
     else
@@ -44,7 +44,7 @@ defmodule Validators.Italy do
     end
   end
 
-  def valid(_, _) do
+  def validate(_, _) do
     {:error, "Tipo de documento inválido"}
   end
 

--- a/lib/validators/italy.ex
+++ b/lib/validators/italy.ex
@@ -2,20 +2,27 @@ defmodule Validators.Italy do
   @moduledoc """
   Validador para los identificadores personales y fiscales de Italia.
   Soporta el NIF (Número de identificación fiscal)
+  Soporta el número de CIE (Carta de Identidad Electrónica)
   """
 
   @doc """
-  Valida el formato del NIF
+  Valida el formato del NIF o el número de CIE
     
   ## Ejemplos:
 
   ```elixir
 
-    iex> Validators.Italy.validate(:nif, "VRDGPP13R10B293P")
+    iex> Validators.Italy.valid(:nif, "VRDGPP13R10B293P")
     {:ok, "VRDGPP13R10B293P"}
 
-    iex> Validators.Italy.validate(:nif, "VRDGPP13R10B29BP")
+    iex> Validators.Italy.valid(:nif, "VRDGPP13R10B29BP")
     {:error, "NIF inválido"}
+
+    iex> Validators.Italy.valid(:cie, "CA00000AA")
+    {:ok, "CA00000AA"}
+
+    iex> Validators.Italy.valid(:cie, "BA00000AA")
+    {:error, "CIE inválido"}
 
   ```    
   """
@@ -28,8 +35,25 @@ defmodule Validators.Italy do
     end
   end
 
+  @spec valid(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def valid(:cie, value) do
+    if Regex.match?(cie(), value) do
+      {:ok, value}
+    else
+      {:error, "CIE inválido"}
+    end
+  end
+
   def valid(_, _) do
     {:error, "Tipo de documento inválido"}
+  end
+
+  # Expresión regular para validar el número de la CIE(Carta de Identidad Electrónica)
+  # Su estructura es iniciar con la letra C, una letra, 5 dígitos y dos letras
+  # ejemplo 'CA00000AA'
+  @spec cie() :: Regex.t()
+  defp cie do
+    ~r/^C[A-Z]\d{5}[A-Z]{2}$/
   end
 
   # Expresión regular para validar el NIF

--- a/lib/validators/mexico.ex
+++ b/lib/validators/mexico.ex
@@ -12,22 +12,22 @@ defmodule Validators.Mexico do
 
   ```elixir
 
-    iex> Validators.Mexico.valid(:curp, "ROCE000131HNLDNDA0")
+    iex> Validators.Mexico.validate(:curp, "ROCE000131HNLDNDA0")
     {:ok, "ROCE000131HNLDNDA0"}
 
-    iex> Validators.Mexico.valid(:curp, "BADD110313HCMLNS0Q")
+    iex> Validators.Mexico.validate(:curp, "BADD110313HCMLNS0Q")
     {:error, "CURP inválido"}
 
-    iex> Validators.Mexico.valid(:rfc, "AAFI7906296J1")
+    iex> Validators.Mexico.validate(:rfc, "AAFI7906296J1")
     {:ok, "AAFI7906296J1"}
 
-    iex> Validators.Mexico.valid(:rfc, "OIBD890101MQB")
+    iex> Validators.Mexico.validate(:rfc, "OIBD890101MQB")
     {:error, "RFC inválido"}
 
   ```
   """
-  @spec valid(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def valid(:curp, value) do
+  @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def validate(:curp, value) do
     if Regex.match?(curp(), value) do
       {:ok, value}
     else
@@ -35,7 +35,7 @@ defmodule Validators.Mexico do
     end
   end
 
-  def valid(:rfc, value) do
+  def validate(:rfc, value) do
     if Regex.match?(rfc(), value) do
       {:ok, value}
     else
@@ -43,7 +43,7 @@ defmodule Validators.Mexico do
     end
   end
 
-  def valid(_, _) do
+  def validate(_, _) do
     {:error, "Tipo de documento inválido"}
   end
 

--- a/lib/validators/mexico.ex
+++ b/lib/validators/mexico.ex
@@ -12,16 +12,16 @@ defmodule Validators.Mexico do
 
   ```elixir
 
-    iex> Validators.Mexico.validate(:curp, "ROCE000131HNLDNDA0")
+    iex> Validators.Mexico.valid(:curp, "ROCE000131HNLDNDA0")
     {:ok, "ROCE000131HNLDNDA0"}
 
-    iex> Validators.Mexico.validate(:curp, "BADD110313HCMLNS0Q")
+    iex> Validators.Mexico.valid(:curp, "BADD110313HCMLNS0Q")
     {:error, "CURP inválido"}
 
-    iex> Validators.Mexico.validate(:rfc, "AAFI7906296J1")
+    iex> Validators.Mexico.valid(:rfc, "AAFI7906296J1")
     {:ok, "AAFI7906296J1"}
 
-    iex> Validators.Mexico.validate(:rfc, "OIBD890101MQB")
+    iex> Validators.Mexico.valid(:rfc, "OIBD890101MQB")
     {:error, "RFC inválido"}
 
   ```

--- a/lib/validators/portugal.ex
+++ b/lib/validators/portugal.ex
@@ -6,21 +6,23 @@ defmodule Validators.Portugal do
 
   @doc """
   Valida el formato del NIF
+  Este identificador se utiliza tanto para documentos personales 
+  como fiscales, segun lo revisado con operaciones
     
   ## Ejemplos:
 
   ```elixir
 
-    iex> Validators.Portugal.valid(:nif, "123456789")
+    iex> Validators.Portugal.validate(:nif, "123456789")
     {:ok, "123456789"}
 
-    iex> Validators.Portugal.valid(:nif, "12345678")
+    iex> Validators.Portugal.validate(:nif, "12345678")
     {:error, "NIF inválido"}
 
   ```    
   """
-  @spec valid(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def valid(:nif, value) do
+  @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def validate(:nif, value) do
     if Regex.match?(nif(), value) do
       {:ok, value}
     else
@@ -28,7 +30,7 @@ defmodule Validators.Portugal do
     end
   end
 
-  def valid(_, _) do
+  def validate(_, _) do
     {:error, "Tipo de documento inválido"}
   end
 

--- a/lib/validators/portugal.ex
+++ b/lib/validators/portugal.ex
@@ -11,10 +11,10 @@ defmodule Validators.Portugal do
 
   ```elixir
 
-    iex> Validators.Portugal.validate(:nif, "123456789")
+    iex> Validators.Portugal.valid(:nif, "123456789")
     {:ok, "123456789"}
 
-    iex> Validators.Portugal.validate(:nif, "12345678")
+    iex> Validators.Portugal.valid(:nif, "12345678")
     {:error, "NIF inválido"}
 
   ```    

--- a/lib/validators/spain.ex
+++ b/lib/validators/spain.ex
@@ -6,23 +6,29 @@ defmodule Validators.Spain do
   """
 
   @doc """
-  Valida el formato del DNI ó el NIE 
+  Valida el formato del DNI, NIE o NIF
 
   ## Ejemplos:
 
   ```elixir
 
-    iex> Validators.Spain.validate(:dni, "46324571H")
+    iex> Validators.Spain.valid(:dni, "46324571H")
     {:ok, "46324571H"}
 
-    iex> Validators.Spain.validate(:dni, "46324571I")
+    iex> Validators.Spain.valid(:dni, "46324571I")
     {:error, "DNI inválido"}
 
-    iex> Validators.Spain.validate(:nie, "Z1234567R")
+    iex> Validators.Spain.valid(:nie, "Z1234567R")
     {:ok, "Z1234567R"}
 
-    iex> Validators.Spain.validate(:nie, "Z1234567I")
+    iex> Validators.Spain.valid(:nie, "Z1234567I")
     {:error, "NIE inválido"}
+
+    iex> Validators.Spain.valid(:nif, "46324571H")
+    {:ok, "46324571H"}
+
+    iex> Validators.Spain.valid(:nif, "46324571I")
+    {:error, "NIF inválido"}    
 
   ```     
   """
@@ -40,6 +46,16 @@ defmodule Validators.Spain do
       {:ok, value}
     else
       {:error, "NIE inválido"}
+    end
+  end
+
+  # El NIF utiliza la misma estructura que un DNI o un NIE
+  # es por eso que se reutilizan las expresiones regulares
+  def valid(:nif, value) do
+    if Regex.match?(dni(), value) or Regex.match?(nie(), value) do
+      {:ok, value}
+    else
+      {:error, "NIF inválido"}
     end
   end
 

--- a/lib/validators/spain.ex
+++ b/lib/validators/spain.ex
@@ -12,28 +12,28 @@ defmodule Validators.Spain do
 
   ```elixir
 
-    iex> Validators.Spain.valid(:dni, "46324571H")
+    iex> Validators.Spain.validate(:dni, "46324571H")
     {:ok, "46324571H"}
 
-    iex> Validators.Spain.valid(:dni, "46324571I")
+    iex> Validators.Spain.validate(:dni, "46324571I")
     {:error, "DNI inválido"}
 
-    iex> Validators.Spain.valid(:nie, "Z1234567R")
+    iex> Validators.Spain.validate(:nie, "Z1234567R")
     {:ok, "Z1234567R"}
 
-    iex> Validators.Spain.valid(:nie, "Z1234567I")
+    iex> Validators.Spain.validate(:nie, "Z1234567I")
     {:error, "NIE inválido"}
 
-    iex> Validators.Spain.valid(:nif, "46324571H")
+    iex> Validators.Spain.validate(:nif, "46324571H")
     {:ok, "46324571H"}
 
-    iex> Validators.Spain.valid(:nif, "46324571I")
+    iex> Validators.Spain.validate(:nif, "46324571I")
     {:error, "NIF inválido"}    
 
   ```     
   """
-  @spec valid(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def valid(:dni, value) do
+  @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def validate(:dni, value) do
     if Regex.match?(dni(), value) do
       {:ok, value}
     else
@@ -41,7 +41,7 @@ defmodule Validators.Spain do
     end
   end
 
-  def valid(:nie, value) do
+  def validate(:nie, value) do
     if Regex.match?(nie(), value) do
       {:ok, value}
     else
@@ -51,7 +51,7 @@ defmodule Validators.Spain do
 
   # El NIF utiliza la misma estructura que un DNI o un NIE
   # es por eso que se reutilizan las expresiones regulares
-  def valid(:nif, value) do
+  def validate(:nif, value) do
     if Regex.match?(dni(), value) or Regex.match?(nie(), value) do
       {:ok, value}
     else
@@ -59,7 +59,7 @@ defmodule Validators.Spain do
     end
   end
 
-  def valid(_, _) do
+  def validate(_, _) do
     {:error, "Tipo de documento inválido"}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bali.MixProject do
   def project do
     [
       app: :bali,
-      version: "0.1.1",
+      version: "0.1.2",
       description: "Validate personal and tax identifiers for mx, co, es, pt, it",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,

--- a/test/bali_test.exs
+++ b/test/bali_test.exs
@@ -42,6 +42,16 @@ defmodule BaliTest do
     assert {:error, "NIE inválido"} == Bali.validate(:es, :nie, value)
   end
 
+  test "Puedo validar el identificador NIF(Número de identificación fiscal) de España exitosamente" do
+    value = "46324571H"
+    assert {:ok, value} == Bali.validate(:es, :nif, value)
+  end
+
+  test "Puedo validar que el identificador NIF(Número de identificación fiscal) de España no es correcto" do
+    value = "46324571I"
+    assert {:error, "NIF inválido"} == Bali.validate(:es, :nif, value)
+  end
+
   test "Puedo validar el identificador CC(Cédula de Ciudadania) de Colombia exitosamente" do
     value = "1234567891"
     assert {:ok, value} == Bali.validate(:co, :cc, value)
@@ -102,8 +112,117 @@ defmodule BaliTest do
     assert {:error, "NIF inválido"} == Bali.validate(:it, :nif, value)
   end
 
+  test "Puedo validar el número de la CIE(Carta de Identidad Electrónica) para Italia exitosamente" do
+    value = "CA00000AA"
+    assert {:ok, value} == Bali.validate(:it, :cie, value)
+  end
+
+  test "Puedo validar el número de la CIE(Carta de Identidad Electrónica) para Italia no es correcto" do
+    value = "BA00000AA"
+    assert {:error, "CIE inválido"} == Bali.validate(:it, :cie, value)
+  end
+
   test "Puedo validar mandar un mensaje de error, si el país no es soportado" do
     assert {:error, "País sk no soportado"} ==
              Bali.validate(:sk, :dni, "12345678A")
+  end
+
+  test "Puedo validar que el documento fiscal para México(rfc), pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "AAFI7906296J1"} == Bali.validate_fiscal(:mx, :rfc, "AAFI7906296J1")
+  end
+
+  test "Puedo validar que el documento fiscal para México(invalid_rfc), no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento fiscal inválido para el país: mx"} ==
+             Bali.validate_fiscal(:mx, :invalid_rfc, "AAFI7906296J1")
+  end
+
+  test "Puedo validar que el documento fiscal para Colombia(nit) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "123456-1"} == Bali.validate_fiscal(:co, :nit, "123456-1")
+  end
+
+  test "Puedo validar que el documento fiscal para Colombia(invalid_nit) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento fiscal inválido para el país: co"} ==
+             Bali.validate_fiscal(:co, :invalid_nit, "123456-1")
+  end
+
+  test "Puedo validar que el documento fiscal para España(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "46324571H"} == Bali.validate_fiscal(:es, :nif, "46324571H")
+  end
+
+  test "Puedo validar que el documento fiscal para España(invalid_nif) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento fiscal inválido para el país: es"} ==
+             Bali.validate_fiscal(:es, :invalid_nif, "46324571H")
+  end
+
+  test "Puedo validar que el documento fiscal para Italia(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "VRDGPP13R10B293P"} == Bali.validate_fiscal(:it, :nif, "VRDGPP13R10B293P")
+  end
+
+  test "Puedo validar que el documento fiscal para Italia(invalid_nif) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento fiscal inválido para el país: it"} ==
+             Bali.validate_fiscal(:it, :invalid_nif, "VRDGPP13R10B293P")
+  end
+
+  test "Puedo validar que el documento fiscal para Portugal(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "123456789"} == Bali.validate_fiscal(:pt, :nif, "123456789")
+  end
+
+  test "Puedo validar que el documento fiscal para Portugal(invalid_nif) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento fiscal inválido para el país: it"} ==
+             Bali.validate_fiscal(:it, :invalid_nif, "123456789")
+  end
+
+  test "Puedo validar que el documento personal para México(rfc) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "ROCE000131HNLDNDA0"} == Bali.validate_personal(:mx, :curp, "ROCE000131HNLDNDA0")
+  end
+
+  test "Puedo validar que el documento personal para México(invalid_rfc) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento personal inválido para el país: mx"} ==
+             Bali.validate_personal(:mx, :invalid_rfc, "AAFI7906296J1")
+  end
+
+  test "Puedo validar que el documento personal para Colombia(cc) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "1234567891"} == Bali.validate_personal(:co, :cc, "1234567891")
+  end
+
+  test "Puedo validar que el documento personal para Colombia(invalid_cc) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento personal inválido para el país: co"} ==
+             Bali.validate_personal(:co, :invalid_cc, "1234567891")
+  end
+
+  test "Puedo validar que el documento personal para Colombia(ce) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "123456"} == Bali.validate_personal(:co, :ce, "123456")
+  end
+
+  test "Puedo validar que el documento personal para Colombia(invalid_ce) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento personal inválido para el país: co"} ==
+             Bali.validate_personal(:co, :invalid_ce, "123456")
+  end
+
+  test "Puedo validar que el documento personal para España(dni) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "46324571H"} == Bali.validate_personal(:es, :dni, "46324571H")
+  end
+
+  test "Puedo validar que el documento personal para España(invalid_dni) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento personal inválido para el país: es"} ==
+             Bali.validate_personal(:es, :invalid_dni, "46324571H")
+  end
+
+  test "Puedo validar que el documento personal para España(nie) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "Z1234567R"} == Bali.validate_personal(:es, :nie, "Z1234567R")
+  end
+
+  test "Puedo validar que el documento personal para España(invalid_nie) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento personal inválido para el país: es"} ==
+             Bali.validate_personal(:es, :invalid_nie, "Z1234567R")
+  end
+
+  test "Puedo validar que el documento personal para Italia(cie) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "CA00000AA"} == Bali.validate_personal(:it, :cie, "CA00000AA")
+  end
+
+  test "Puedo validar que el documento personal para Italia(invalid_cie) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento personal inválido para el país: it"} ==
+             Bali.validate_personal(:it, :invalid_cie, "CA00000AA")
   end
 end

--- a/test/bali_test.exs
+++ b/test/bali_test.exs
@@ -128,101 +128,112 @@ defmodule BaliTest do
   end
 
   test "Puedo validar que el documento fiscal para México(rfc), pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "AAFI7906296J1"} == Bali.validate_fiscal(:mx, :rfc, "AAFI7906296J1")
+    assert {:ok, "AAFI7906296J1"} == Bali.validate_fiscal_document(:mx, :rfc, "AAFI7906296J1")
   end
 
   test "Puedo validar que el documento fiscal para México(invalid_rfc), no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento fiscal inválido para el país: mx"} ==
-             Bali.validate_fiscal(:mx, :invalid_rfc, "AAFI7906296J1")
+             Bali.validate_fiscal_document(:mx, :invalid_rfc, "AAFI7906296J1")
   end
 
   test "Puedo validar que el documento fiscal para Colombia(nit) pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "123456-1"} == Bali.validate_fiscal(:co, :nit, "123456-1")
+    assert {:ok, "123456-1"} == Bali.validate_fiscal_document(:co, :nit, "123456-1")
   end
 
   test "Puedo validar que el documento fiscal para Colombia(invalid_nit) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento fiscal inválido para el país: co"} ==
-             Bali.validate_fiscal(:co, :invalid_nit, "123456-1")
+             Bali.validate_fiscal_document(:co, :invalid_nit, "123456-1")
   end
 
   test "Puedo validar que el documento fiscal para España(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "46324571H"} == Bali.validate_fiscal(:es, :nif, "46324571H")
+    assert {:ok, "46324571H"} == Bali.validate_fiscal_document(:es, :nif, "46324571H")
   end
 
   test "Puedo validar que el documento fiscal para España(invalid_nif) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento fiscal inválido para el país: es"} ==
-             Bali.validate_fiscal(:es, :invalid_nif, "46324571H")
+             Bali.validate_fiscal_document(:es, :invalid_nif, "46324571H")
   end
 
   test "Puedo validar que el documento fiscal para Italia(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "VRDGPP13R10B293P"} == Bali.validate_fiscal(:it, :nif, "VRDGPP13R10B293P")
+    assert {:ok, "VRDGPP13R10B293P"} ==
+             Bali.validate_fiscal_document(:it, :nif, "VRDGPP13R10B293P")
   end
 
   test "Puedo validar que el documento fiscal para Italia(invalid_nif) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento fiscal inválido para el país: it"} ==
-             Bali.validate_fiscal(:it, :invalid_nif, "VRDGPP13R10B293P")
+             Bali.validate_fiscal_document(:it, :invalid_nif, "VRDGPP13R10B293P")
   end
 
   test "Puedo validar que el documento fiscal para Portugal(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "123456789"} == Bali.validate_fiscal(:pt, :nif, "123456789")
+    assert {:ok, "123456789"} == Bali.validate_fiscal_document(:pt, :nif, "123456789")
   end
 
   test "Puedo validar que el documento fiscal para Portugal(invalid_nif) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento fiscal inválido para el país: it"} ==
-             Bali.validate_fiscal(:it, :invalid_nif, "123456789")
+             Bali.validate_fiscal_document(:it, :invalid_nif, "123456789")
   end
 
   test "Puedo validar que el documento personal para México(rfc) pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "ROCE000131HNLDNDA0"} == Bali.validate_personal(:mx, :curp, "ROCE000131HNLDNDA0")
+    assert {:ok, "ROCE000131HNLDNDA0"} ==
+             Bali.validate_personal_document(:mx, :curp, "ROCE000131HNLDNDA0")
   end
 
   test "Puedo validar que el documento personal para México(invalid_rfc) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento personal inválido para el país: mx"} ==
-             Bali.validate_personal(:mx, :invalid_rfc, "AAFI7906296J1")
+             Bali.validate_personal_document(:mx, :invalid_rfc, "AAFI7906296J1")
   end
 
   test "Puedo validar que el documento personal para Colombia(cc) pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "1234567891"} == Bali.validate_personal(:co, :cc, "1234567891")
+    assert {:ok, "1234567891"} == Bali.validate_personal_document(:co, :cc, "1234567891")
   end
 
   test "Puedo validar que el documento personal para Colombia(invalid_cc) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento personal inválido para el país: co"} ==
-             Bali.validate_personal(:co, :invalid_cc, "1234567891")
+             Bali.validate_personal_document(:co, :invalid_cc, "1234567891")
   end
 
   test "Puedo validar que el documento personal para Colombia(ce) pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "123456"} == Bali.validate_personal(:co, :ce, "123456")
+    assert {:ok, "123456"} == Bali.validate_personal_document(:co, :ce, "123456")
   end
 
   test "Puedo validar que el documento personal para Colombia(invalid_ce) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento personal inválido para el país: co"} ==
-             Bali.validate_personal(:co, :invalid_ce, "123456")
+             Bali.validate_personal_document(:co, :invalid_ce, "123456")
   end
 
   test "Puedo validar que el documento personal para España(dni) pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "46324571H"} == Bali.validate_personal(:es, :dni, "46324571H")
+    assert {:ok, "46324571H"} == Bali.validate_personal_document(:es, :dni, "46324571H")
   end
 
   test "Puedo validar que el documento personal para España(invalid_dni) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento personal inválido para el país: es"} ==
-             Bali.validate_personal(:es, :invalid_dni, "46324571H")
+             Bali.validate_personal_document(:es, :invalid_dni, "46324571H")
   end
 
   test "Puedo validar que el documento personal para España(nie) pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "Z1234567R"} == Bali.validate_personal(:es, :nie, "Z1234567R")
+    assert {:ok, "Z1234567R"} == Bali.validate_personal_document(:es, :nie, "Z1234567R")
   end
 
   test "Puedo validar que el documento personal para España(invalid_nie) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento personal inválido para el país: es"} ==
-             Bali.validate_personal(:es, :invalid_nie, "Z1234567R")
+             Bali.validate_personal_document(:es, :invalid_nie, "Z1234567R")
   end
 
   test "Puedo validar que el documento personal para Italia(cie) pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "CA00000AA"} == Bali.validate_personal(:it, :cie, "CA00000AA")
+    assert {:ok, "CA00000AA"} == Bali.validate_personal_document(:it, :cie, "CA00000AA")
   end
 
   test "Puedo validar que el documento personal para Italia(invalid_cie) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento personal inválido para el país: it"} ==
-             Bali.validate_personal(:it, :invalid_cie, "CA00000AA")
+             Bali.validate_personal_document(:it, :invalid_cie, "CA00000AA")
+  end
+
+  test "Puedo validar que el documento personal para Portugal(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "123456789"} == Bali.validate_personal_document(:pt, :nif, "123456789")
+  end
+
+  test "Puedo validar que el documento personal para Portugal(invalid_nif) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento personal inválido para el país: pt"} ==
+             Bali.validate_personal_document(:pt, :invalid_nif, "123456789")
   end
 end

--- a/test/validators/colombia_test.exs
+++ b/test/validators/colombia_test.exs
@@ -5,56 +5,56 @@ defmodule Validators.ColombiaTest do
 
   test "Puedo validar que la CC es correcta a 6 dígitos" do
     value = "123456"
-    assert {:ok, value} == Colombia.valid(:cc, value)
+    assert {:ok, value} == Colombia.validate(:cc, value)
   end
 
   test "Puedo validar que la CC es correcta a 7 dígitos" do
     value = "1234567"
-    assert {:ok, value} == Colombia.valid(:cc, value)
+    assert {:ok, value} == Colombia.validate(:cc, value)
   end
 
   test "Puedo validar que la CC es correcta a 8 dígitos" do
     value = "12345678"
-    assert {:ok, value} == Colombia.valid(:cc, value)
+    assert {:ok, value} == Colombia.validate(:cc, value)
   end
 
   test "Puedo validar que la CC es correcta a 9 dígitos" do
     value = "123456789"
-    assert {:ok, value} == Colombia.valid(:cc, value)
+    assert {:ok, value} == Colombia.validate(:cc, value)
   end
 
   test "Puedo validar que la CC es correcta a 10 dígitos" do
     value = "1234567891"
-    assert {:ok, value} == Colombia.valid(:cc, value)
+    assert {:ok, value} == Colombia.validate(:cc, value)
   end
 
   test "Puedo verificar que la CC es inválida a 11 dígitos" do
     value = "12345678912"
-    assert {:error, "CC inválida"} == Colombia.valid(:cc, value)
+    assert {:error, "CC inválida"} == Colombia.validate(:cc, value)
   end
 
   test "Puedo validar que la CE es correcta a 6 dígitos" do
     value = "123456"
-    assert {:ok, value} == Colombia.valid(:ce, value)
+    assert {:ok, value} == Colombia.validate(:ce, value)
   end
 
   test "Puedo verificar que la CE es inválida a 7 dígitos" do
     value = "1234567"
-    assert {:error, "CE inválida"} == Colombia.valid(:ce, value)
+    assert {:error, "CE inválida"} == Colombia.validate(:ce, value)
   end
 
   test "Puedo validar que el NIT es correcto a 6 digitos y un dígito verificador" do
     value = "123456-1"
-    assert {:ok, value} == Colombia.valid(:nit, value)
+    assert {:ok, value} == Colombia.validate(:nit, value)
   end
 
   test "Puedo verificar que el NIT es inválido a 6 digitos y dos dígitos extra" do
     value = "123456-12"
-    assert {:error, "NIT inválido"} == Colombia.valid(:nit, value)
+    assert {:error, "NIT inválido"} == Colombia.validate(:nit, value)
   end
 
   test "Puedo validar si me mandan el parámetro de identificación y valor incorrectos se envia un mensaje de error" do
     assert {:error, "Tipo de documento inválido"} ==
-             Colombia.valid(:ab, "12345678A")
+             Colombia.validate(:ab, "12345678A")
   end
 end

--- a/test/validators/italy_test.exs
+++ b/test/validators/italy_test.exs
@@ -7,26 +7,26 @@ defmodule Validators.ItalyTest do
 
   test "Puedo validar el NIF(Número de identificación fiscal) para Italia" do
     value = "VRDGPP13R10B293P"
-    assert {:ok, value} == Italy.valid(:nif, value)
+    assert {:ok, value} == Italy.validate(:nif, value)
   end
 
   test "Puedo validar que el NIF(Número de identificación fiscal) para Italia no es correcto" do
     value = "VRDGPP13R10B29BP"
-    assert {:error, "NIF inválido"} == Italy.valid(:nif, value)
+    assert {:error, "NIF inválido"} == Italy.validate(:nif, value)
   end
 
   test "Puedo validar el número de la CIE(Carta de Identidad Electrónica) para Italia" do
     value = "CA00000AA"
-    assert {:ok, value} == Italy.valid(:cie, value)
+    assert {:ok, value} == Italy.validate(:cie, value)
   end
 
   test "Puedo validar el número de la CIE(Carta de Identidad Electrónica) para Italia no es correcto" do
     value = "BA00000AA"
-    assert {:error, "CIE inválido"} == Italy.valid(:cie, value)
+    assert {:error, "CIE inválido"} == Italy.validate(:cie, value)
   end
 
   test "Puedo validar si me mandan el parámetro de identificación y valor incorrectos se envia un mensaje de error" do
     assert {:error, "Tipo de documento inválido"} ==
-             Italy.valid(:sk, "12345678A")
+             Italy.validate(:sk, "12345678A")
   end
 end

--- a/test/validators/italy_test.exs
+++ b/test/validators/italy_test.exs
@@ -15,6 +15,16 @@ defmodule Validators.ItalyTest do
     assert {:error, "NIF inválido"} == Italy.valid(:nif, value)
   end
 
+  test "Puedo validar el número de la CIE(Carta de Identidad Electrónica) para Italia" do
+    value = "CA00000AA"
+    assert {:ok, value} == Italy.valid(:cie, value)
+  end
+
+  test "Puedo validar el número de la CIE(Carta de Identidad Electrónica) para Italia no es correcto" do
+    value = "BA00000AA"
+    assert {:error, "CIE inválido"} == Italy.valid(:cie, value)
+  end
+
   test "Puedo validar si me mandan el parámetro de identificación y valor incorrectos se envia un mensaje de error" do
     assert {:error, "Tipo de documento inválido"} ==
              Italy.valid(:sk, "12345678A")

--- a/test/validators/mexico_test.exs
+++ b/test/validators/mexico_test.exs
@@ -5,26 +5,26 @@ defmodule Validators.MexicoTest do
 
   test "Puedo validar que el RFC es correcto" do
     value = "AAFI7906296J1"
-    assert {:ok, value} == Mexico.valid(:rfc, value)
+    assert {:ok, value} == Mexico.validate(:rfc, value)
   end
 
   test "Puedo verificar que el RFC es incorrecto" do
     value = "OIBD890101MQB"
-    assert {:error, "RFC inválido"} == Mexico.valid(:rfc, value)
+    assert {:error, "RFC inválido"} == Mexico.validate(:rfc, value)
   end
 
   test "Puedo validar que el CURP es correcto" do
     value = "ROCE000131HNLDNDA0"
-    assert {:ok, value} == Mexico.valid(:curp, value)
+    assert {:ok, value} == Mexico.validate(:curp, value)
   end
 
   test "Puedo validar que el CURP es incorrecto" do
     value = "BADD110313HCMLNS0Q"
-    assert {:error, "CURP inválido"} == Mexico.valid(:curp, value)
+    assert {:error, "CURP inválido"} == Mexico.validate(:curp, value)
   end
 
   test "Puedo validar si me mandan el parámetro de identificación y valor incorrectos se envia un mensaje de error" do
     assert {:error, "Tipo de documento inválido"} ==
-             Mexico.valid(:ab, "12345678A")
+             Mexico.validate(:ab, "12345678A")
   end
 end

--- a/test/validators/portugal_test.exs
+++ b/test/validators/portugal_test.exs
@@ -5,16 +5,16 @@ defmodule Validators.PortugalTest do
 
   test "Puedo validar el NIF(Número de identificación fiscal) para Portugal" do
     value = "123456789"
-    assert {:ok, "123456789"} == Portugal.valid(:nif, value)
+    assert {:ok, "123456789"} == Portugal.validate(:nif, value)
   end
 
   test "Puedo validar el NIF(Número de identificación fiscal) para Portugal no es correcto" do
     value = "12345678"
-    assert {:error, "NIF inválido"} == Portugal.valid(:nif, value)
+    assert {:error, "NIF inválido"} == Portugal.validate(:nif, value)
   end
 
   test "Puedo validar si me mandan el parámetro de identificación y valor incorrectos se envia un mensaje de error" do
     assert {:error, "Tipo de documento inválido"} ==
-             Portugal.valid(:sk, "12345678A")
+             Portugal.validate(:sk, "12345678A")
   end
 end

--- a/test/validators/spain_test.exs
+++ b/test/validators/spain_test.exs
@@ -5,36 +5,36 @@ defmodule Validators.SpainTest do
 
   test "Puedo validar que el DNI(Documento Nacional de Identidad) es correcto" do
     value = "46324571H"
-    assert {:ok, "46324571H"} == Spain.valid(:dni, value)
+    assert {:ok, "46324571H"} == Spain.validate(:dni, value)
   end
 
   test "Puedo validar que el DNI(Documento Nacional de Identidad) es incorrecto" do
     value = "46324571I"
-    assert {:error, "DNI inválido"} == Spain.valid(:dni, value)
+    assert {:error, "DNI inválido"} == Spain.validate(:dni, value)
   end
 
   test "Puedo validar que el NIE(Número de identificación al Extranjero) es correcto" do
     value = "Z1234567R"
-    assert {:ok, "Z1234567R"} == Spain.valid(:nie, value)
+    assert {:ok, "Z1234567R"} == Spain.validate(:nie, value)
   end
 
   test "Puedo validar que el NIE(Número de identificación al Extranjero) es incorrecto" do
     value = "Z1234567I"
-    assert {:error, "NIE inválido"} == Spain.valid(:nie, value)
+    assert {:error, "NIE inválido"} == Spain.validate(:nie, value)
   end
 
   test "Puedo validar que el NIF(Número de identificación fiscal) es correcto" do
     value = "46324571H"
-    assert {:ok, "46324571H"} == Spain.valid(:nif, value)
+    assert {:ok, "46324571H"} == Spain.validate(:nif, value)
   end
 
   test "Puedo validar que el NIF(Número de identificación fiscal) es incorrecto" do
     value = "46324571I"
-    assert {:error, "NIF inválido"} == Spain.valid(:nif, value)
+    assert {:error, "NIF inválido"} == Spain.validate(:nif, value)
   end
 
   test "Puedo validar si me mandan el parámetro de identificación y valor incorrectos se envia un mensaje de error" do
     assert {:error, "Tipo de documento inválido"} ==
-             Spain.valid(:es, "12345678A")
+             Spain.validate(:es, "12345678A")
   end
 end

--- a/test/validators/spain_test.exs
+++ b/test/validators/spain_test.exs
@@ -23,6 +23,16 @@ defmodule Validators.SpainTest do
     assert {:error, "NIE inválido"} == Spain.valid(:nie, value)
   end
 
+  test "Puedo validar que el NIF(Número de identificación fiscal) es correcto" do
+    value = "46324571H"
+    assert {:ok, "46324571H"} == Spain.valid(:nif, value)
+  end
+
+  test "Puedo validar que el NIF(Número de identificación fiscal) es incorrecto" do
+    value = "46324571I"
+    assert {:error, "NIF inválido"} == Spain.valid(:nif, value)
+  end
+
   test "Puedo validar si me mandan el parámetro de identificación y valor incorrectos se envia un mensaje de error" do
     assert {:error, "Tipo de documento inválido"} ==
              Spain.valid(:es, "12345678A")


### PR DESCRIPTION
### ¿Qué hice?

- Agregue dos métodos para validar que el documento recibido ya sea fiscal o personal exista dentro del conjunto de documentos válidos y una vez realizado esto, verificar su valor
- Se agrego la validación del documento personal CIE(Carta de Identidad Electrónica) para Italia
- Se agrego la validación para el NIF(Número de identificación fiscal) para España
- Se agregaron las pruebas correspondientes 
- Se realizo un fix en los doctests ya que había un typo
- Issue relacionado [1397](https://github.com/resuelve/platform/issues/1397)