### PR TITLE
Bugfix para las funciones que validan un documentos personales y fiscales

### DIFF
--- a/lib/bali.ex
+++ b/lib/bali.ex
@@ -151,7 +151,7 @@ defmodule Bali do
 
       tax_documents_per_country ->
         if Enum.member?(tax_documents_per_country, Atom.to_string(document_type)) do
-          do_validate(country, document_type, value)
+          validate(country, document_type, value)
         else
           {:error, "Documento fiscal inválido para el país: #{country}"}
         end
@@ -171,7 +171,7 @@ defmodule Bali do
 
       personal_documents_per_country ->
         if Enum.member?(personal_documents_per_country, Atom.to_string(document_type)) do
-          do_validate(country, document_type, value)
+          validate(country, document_type, value)
         else
           {:error, "Documento personal inválido para el país: #{country}"}
         end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bali.MixProject do
   def project do
     [
       app: :bali,
-      version: "0.1.2",
+      version: "0.1.3",
       description: "Validate personal and tax identifiers for mx, co, es, pt, it",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### ¿Qué hice?

- Se realiza fix para invocar a la función `validate` que se encarga de limpiar el valor recibido antes de realizar la validación del documento, ya que ahora se está invocando a la función `do_validate` la cual invoca directamente al validador del país