### PR TITLE
Added validation of CPF and CNPJ for Brazil

### DIFF
--- a/lib/bali.ex
+++ b/lib/bali.ex
@@ -1,7 +1,7 @@
 defmodule Bali do
   @moduledoc """
-  Módulo encargado de realizar las validaciones de identificadores personales 
-  y fiscales de México, Colombia, España, Portugal e Italia
+  Módulo encargado de realizar las validaciones de identificadores personales
+  y fiscales de México, Colombia, España, Portugal, Italia y Brasil
   """
 
   alias Validators.Portugal
@@ -9,13 +9,15 @@ defmodule Bali do
   alias Validators.Colombia
   alias Validators.Mexico
   alias Validators.Italy
+  alias Validators.Brazil
 
   @tax_documents %{
     mx: ["rfc"],
     co: ["nit"],
     es: ["nif"],
     it: ["nif"],
-    pt: ["nif"]
+    pt: ["nif"],
+    br: ["cnpj"]
   }
 
   @personal_documents %{
@@ -23,11 +25,12 @@ defmodule Bali do
     co: ["cc", "ce"],
     es: ["dni", "nie"],
     it: ["cie"],
-    pt: ["nif"]
+    pt: ["nif"],
+    br: ["cpf"]
   }
 
   @doc """
-  Valida el identificador personal o fiscal segun el país(mx,co,es,pt,it) y tipo 
+  Valida el identificador personal o fiscal segun el país(mx,co,es,pt,it,br) y tipo
 
   ## Ejemplos:
 
@@ -44,9 +47,9 @@ defmodule Bali do
     {:ok, "AAFI7906296J1"}
 
     iex> Bali.validate(:mx, :rfc, "OIBD890101MQB")
-    {:error, "RFC inválido"}    
+    {:error, "RFC inválido"}
 
-    # Colombia  
+    # Colombia
     iex> Bali.validate(:co, :cc, "123456789")
     {:ok, "123456789"}
 
@@ -57,13 +60,13 @@ defmodule Bali do
     {:ok, "123456"}
 
     iex> Bali.validate(:co, :ce, "1234567")
-    {:error, "CE inválida"}    
+    {:error, "CE inválida"}
 
     iex> Bali.validate(:co, :nit, "123456-1")
     {:ok, "123456-1"}
 
     iex> Bali.validate(:co, :nit, "123456-12")
-    {:error, "NIT inválido"}    
+    {:error, "NIT inválido"}
 
     # España
     iex> Bali.validate(:es, :dni, "46324571H")
@@ -76,15 +79,15 @@ defmodule Bali do
     {:ok, "Z1234567R"}
 
     iex> Bali.validate(:es, :nie, "Z1234567I")
-    {:error, "NIE inválido"}    
+    {:error, "NIE inválido"}
 
     # Italia
     iex> Bali.validate(:it, :nif, "VRDGPP13R10B293P")
     {:ok, "VRDGPP13R10B293P"}
 
     iex> Bali.validate(:it, :nif, "VRDGPP13R10B29BP")
-    {:error, "NIF inválido"}    
-    
+    {:error, "NIF inválido"}
+
     # Portugal
     iex> Bali.validate(:pt, :nif, "123456789")
     {:ok, "123456789"}
@@ -92,7 +95,20 @@ defmodule Bali do
     iex> Bali.validate(:pt, :nif, "12345678")
     {:error, "NIF inválido"}
 
-  ```      
+    # Brasil
+    iex> Bali.validate(:br, :cpf, "000.000.000-00")
+    {:ok, "000.000.000-00"}
+
+    iex> Bali.validate(:br, :cpf, "000.000.000-000")
+    {:error, "CPF inválido"}
+
+    iex> Bali.validate(:br, :cnpj, "00.000.000/0000-00")
+    {:ok, "00.000.000/0000-00"}
+
+    iex> Bali.validate(:br, :cnpj, "00.000.000/0000-000")
+    {:error, "CNPJ inválido"}
+
+  ```
   """
   @spec validate(atom, atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def validate(country, document_type, value) do
@@ -121,6 +137,10 @@ defmodule Bali do
     Italy.validate(document_type, value)
   end
 
+  defp do_validate(:br, document_type, value) do
+    Brazil.validate(document_type, value)
+  end
+
   defp do_validate(country, _document_type, _value) do
     {:error, "País #{country} no soportado"}
   end
@@ -135,7 +155,7 @@ defmodule Bali do
   Obtiene la lista de tipos de documentos soportados
   """
   def get_document_types do
-    ["DNI", "NIE", "NIF", "RFC", "CURP", "CC", "CE", "NIT"]
+    ["DNI", "NIE", "NIF", "RFC", "CURP", "CC", "CE", "NIT", "CPF", "CNPJ"]
   end
 
   @doc """

--- a/lib/validators/brazil.ex
+++ b/lib/validators/brazil.ex
@@ -1,0 +1,66 @@
+defmodule Validators.Brazil do
+  @moduledoc """
+  Validador para los identificadores personales y fiscales de Brazil.
+  Soporta el CPF (Cadastro de Pessoas Físicas)
+  Soporta el CNPJ (Cadastro Nacional de Pessoas Jurídicas)
+  """
+
+  @doc """
+  Valida el formato del CPF o el CNPJ
+
+  ## Ejemplos:
+
+  ```elixir
+
+    iex> Validators.Brazil.validate(:cpf, "000.000.000-00")
+    {:ok, "000.000.000-00"}
+
+    iex> Validators.Brazil.validate(:cpf, "0000.000.000-000")
+    {:error, "CPF inválido"}
+
+    iex> Validators.Brazil.validate(:cnpj, "00.000.000/0000-00")
+    {:ok, "00.000.000/0000-00"}
+
+    iex> Validators.Brazil.validate(:cnpj, "00.000.000/0000-000")
+    {:error, "CNPJ inválido"}
+
+  ```
+  """
+  @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def validate(:cpf, value) do
+    if Regex.match?(cpf(), value) do
+      {:ok, value}
+    else
+      {:error, "CPF inválido"}
+    end
+  end
+
+  def validate(:cnpj, value) do
+    if Regex.match?(cnpj(), value) do
+      {:ok, value}
+    else
+      {:error, "CNPJ inválido"}
+    end
+  end
+
+  def validate(_, _) do
+    {:error, "Tipo de documento inválido"}
+  end
+
+  # Expresión regular para validar el CPF
+  # Su estructura es tres bloques de 3 dígitos separados por un punto, un guión y dos dígitos
+  # Ejemplo 000.000.000-00
+  @spec cpf() :: Regex.t()
+  defp cpf do
+    ~r/^\d{3}.\d{3}.\d{3}-\d{2}$/
+  end
+
+  # Expresión regular para validar el CNPJ
+  # Su estructura es tres bloques de 2, 3 y 3 dígitos respectivamente separados por un punto,
+  # seguido de una diagonal un bloque de 4 dígitos un guión y dos dígitos
+  # Ejemplo 00.000.000/0000-00
+  @spec cnpj() :: Regex.t()
+  defp cnpj do
+    ~r/^\d{2}.\d{3}.\d{3}\/\d{4}-\d{2}$/
+  end
+end

--- a/lib/validators/italy.ex
+++ b/lib/validators/italy.ex
@@ -7,7 +7,7 @@ defmodule Validators.Italy do
 
   @doc """
   Valida el formato del NIF o el número de CIE
-    
+
   ## Ejemplos:
 
   ```elixir
@@ -24,7 +24,7 @@ defmodule Validators.Italy do
     iex> Validators.Italy.validate(:cie, "BA00000AA")
     {:error, "CIE inválido"}
 
-  ```    
+  ```
   """
   @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def validate(:nif, value) do
@@ -35,7 +35,6 @@ defmodule Validators.Italy do
     end
   end
 
-  @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def validate(:cie, value) do
     if Regex.match?(cie(), value) do
       {:ok, value}

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Bali.MixProject do
     [
       app: :bali,
       version: "0.1.3",
-      description: "Validate personal and tax identifiers for mx, co, es, pt, it",
+      description: "Validate personal and tax identifiers for mx, co, es, pt, it, br",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/bali_test.exs
+++ b/test/bali_test.exs
@@ -122,6 +122,26 @@ defmodule BaliTest do
     assert {:error, "CIE inválido"} == Bali.validate(:it, :cie, value)
   end
 
+  test "Puedo validar el CPF(Cadastro de Pessoas Físicas) para Brazil" do
+    value = "123.456.789-01"
+    assert {:ok, value} == Bali.validate(:br, :cpf, value)
+  end
+
+  test "Puedo validar que el CPF(Cadastro de Pessoas Físicas) para Brazil no es correcto" do
+    value = "123.456.7889-A1"
+    assert {:error, "CPF inválido"} == Bali.validate(:br, :cpf, value)
+  end
+
+  test "Puedo validar el número de la CNPJ(Cadastro Nacional de Pessoas Jurídicas) para Brazil" do
+    value = "12.345.678/1234-56"
+    assert {:ok, value} == Bali.validate(:br, :cnpj, value)
+  end
+
+  test "Puedo validar el número de la CNPJ(Cadastro Nacional de Pessoas Jurídicas) para Brazil no es correcto" do
+    value = "12.345.678/1234-569"
+    assert {:error, "CNPJ inválido"} == Bali.validate(:br, :cnpj, value)
+  end
+
   test "Puedo validar mandar un mensaje de error, si el país no es soportado" do
     assert {:error, "País sk no soportado"} ==
              Bali.validate(:sk, :dni, "12345678A")
@@ -162,6 +182,16 @@ defmodule BaliTest do
   test "Puedo validar que el documento fiscal para Italia(invalid_nif) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento fiscal inválido para el país: it"} ==
              Bali.validate_fiscal_document(:it, :invalid_nif, "VRDGPP13R10B293P")
+  end
+
+  test "Puedo validar que el documento fiscal para Brasil(cnpj) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "12.345.678/1234-56"} ==
+             Bali.validate_fiscal_document(:br, :cnpj, "12.345.678/1234-56")
+  end
+
+  test "Puedo validar que el documento fiscal para Brasil(invalid_cnpj) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento fiscal inválido para el país: br"} ==
+             Bali.validate_fiscal_document(:br, :invalid_cnpj, "12.345.678/1234-56")
   end
 
   test "Puedo validar que el documento fiscal para Portugal(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do
@@ -226,6 +256,15 @@ defmodule BaliTest do
   test "Puedo validar que el documento personal para Italia(invalid_cie) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento personal inválido para el país: it"} ==
              Bali.validate_personal_document(:it, :invalid_cie, "CA00000AA")
+  end
+
+  test "Puedo validar que el documento personal para Brasil(cpf) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "123.456.789-01"} == Bali.validate_personal_document(:br, :cpf, "123.456.789-01")
+  end
+
+  test "Puedo validar que el documento personal para Brasil(invalid_cpf) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento personal inválido para el país: br"} ==
+             Bali.validate_personal_document(:br, :invalid_cpf, "123.456.789-01")
   end
 
   test "Puedo validar que el documento personal para Portugal(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do

--- a/test/bali_test.exs
+++ b/test/bali_test.exs
@@ -199,8 +199,8 @@ defmodule BaliTest do
   end
 
   test "Puedo validar que el documento fiscal para Portugal(invalid_nif) no pertenece al conjunto de documentos válidos" do
-    assert {:error, "Documento fiscal inválido para el país: it"} ==
-             Bali.validate_fiscal_document(:it, :invalid_nif, "123456789")
+    assert {:error, "Documento fiscal inválido para el país: pt"} ==
+             Bali.validate_fiscal_document(:pt, :invalid_nif, "123456789")
   end
 
   test "Puedo validar que el documento personal para México(rfc) pertenece al conjunto de documentos válidos y su valor es correcto" do

--- a/test/validators/brazil_test.exs
+++ b/test/validators/brazil_test.exs
@@ -1,0 +1,30 @@
+defmodule Validators.BrazilTest do
+  use ExUnit.Case
+
+  alias Validators.Brazil
+
+  test "Puedo validar el CPF(Cadastro de Pessoas Físicas) para Brazil" do
+    value = "123.456.789-01"
+    assert {:ok, value} == Brazil.validate(:cpf, value)
+  end
+
+  test "Puedo validar que el CPF(Cadastro de Pessoas Físicas) para Brazil no es correcto" do
+    value = "123.456.7889-A1"
+    assert {:error, "CPF inválido"} == Brazil.validate(:cpf, value)
+  end
+
+  test "Puedo validar el número de la CNPJ(Cadastro Nacional de Pessoas Jurídicas) para Brazil" do
+    value = "12.345.678/1234-56"
+    assert {:ok, value} == Brazil.validate(:cnpj, value)
+  end
+
+  test "Puedo validar el número de la CNPJ(Cadastro Nacional de Pessoas Jurídicas) para Brazil no es correcto" do
+    value = "12.345.678/1234-569"
+    assert {:error, "CNPJ inválido"} == Brazil.validate(:cnpj, value)
+  end
+
+  test "Puedo validar si me mandan el parámetro de identificación y valor incorrectos se envia un mensaje de error" do
+    assert {:error, "Tipo de documento inválido"} ==
+             Brazil.validate(:sk, "12345678A")
+  end
+end

--- a/test/validators/italy_test.exs
+++ b/test/validators/italy_test.exs
@@ -1,8 +1,6 @@
 defmodule Validators.ItalyTest do
   use ExUnit.Case
 
-  use ExUnit.Case
-
   alias Validators.Italy
 
   test "Puedo validar el NIF(Número de identificación fiscal) para Italia" do


### PR DESCRIPTION
### ¿Qué hice?

- Agrega al módulo principal, el validador de identificadores para Brasil
- Genere el módulo para agregar las validaciones para Brasil en este caso el CPF (Cadastro de Pessoas Físicas) y CNPJ (Cadastro Nacional de Pessoas Jurídicas)
- Corregir formato en el repositorio
- Corregir un test que tenia el país incorrecto

### Issue relacionado 
- resuelve/platform#3027