### PR TITLE
Add step to CI to auto publish package when a new tag is created

### DIFF
--- a/.ci.yml
+++ b/.ci.yml
@@ -5,15 +5,76 @@ steps:
 - name: test
   pull: if-not-exists
   image: elixir:1.11-alpine
+  environment:
+    MIX_ENV: test
   commands:
-  - apk add --update bash openssl git  
+  - apk add --update bash openssl git
   - mix local.hex --force && mix local.rebar --force
   - mix deps.get
-  - mix format --check-formatted
-  - mix xref unreachable --abort-if-any
-  - mix test --cover
+  - mix compile --warnings-as-errors
+  - mix ci
   when:
     event:
     - pull_request
     status:
     - success
+
+- name: notify
+  pull: if-not-exists
+  image: resuelve/drone-fish
+  environment:
+    GOOGLE_CHAT_URL:
+      from_secret: google_chat_url
+  when:
+    event:
+    - pull_request
+    status:
+    - success
+    - failure
+
+---
+kind: pipeline
+name: publish
+
+trigger:
+  event:
+  - tag
+
+clone:
+  disable: true
+
+steps:
+- name: clone
+  pull: if-not-exists
+  image: plugins/git
+  when:
+    status:
+    - success
+
+- name: publish
+  image: elixir:1.11-alpine
+  commands:
+  - apk add --update bash openssl git
+  - mix local.hex --force && mix local.rebar --force
+  - mix deps.get
+  - mix compile --warnings-as-errors
+  - HEX_API_KEY=$HEX_KEY mix hex.publish --yes
+  environment:
+    HEX_KEY:
+      from_secret: hex_key
+  when:
+    status:
+    - success
+
+- name: notify
+  pull: if-not-exists
+  image: resuelve/drone-fish
+  environment:
+    GOOGLE_CHAT_URL:
+      from_secret: google_chat_url
+  when:
+    status:
+    - success
+    - failure
+
+...

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,8 @@ defmodule Bali.MixProject do
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      package: package()
+      package: package(),
+      aliases: aliases()
     ]
   end
 
@@ -33,6 +34,12 @@ defmodule Bali.MixProject do
       maintainers: ["Iván Álvarez"],
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => "https://github.com/resuelve/bali"}
+    ]
+  end
+
+  defp aliases do
+    [
+      ci: ["format --check-formatted", "xref unreachable --abort-if-any", "test --cover"]
     ]
   end
 end


### PR DESCRIPTION
We needed a way to publish this package as soon a new tag version is
created to have a dependency on a person o group of persons who have
access to hex.pm