### PR TITLE
Add namespace Bali to validation modules

### DIFF
--- a/lib/bali.ex
+++ b/lib/bali.ex
@@ -4,12 +4,14 @@ defmodule Bali do
   y fiscales de México, Colombia, España, Portugal, Italia y Brasil
   """
 
-  alias Validators.Portugal
-  alias Validators.Spain
-  alias Validators.Colombia
-  alias Validators.Mexico
-  alias Validators.Italy
-  alias Validators.Brazil
+  alias Bali.Validators.{
+    Portugal,
+    Brazil,
+    Colombia,
+    Italy,
+    Mexico,
+    Spain
+  }
 
   @tax_documents %{
     mx: ["rfc"],

--- a/lib/validators/brazil.ex
+++ b/lib/validators/brazil.ex
@@ -1,4 +1,4 @@
-defmodule Validators.Brazil do
+defmodule Bali.Validators.Brazil do
   @moduledoc """
   Validador para los identificadores personales y fiscales de Brazil.
   Soporta el CPF (Cadastro de Pessoas Físicas)
@@ -12,16 +12,16 @@ defmodule Validators.Brazil do
 
   ```elixir
 
-    iex> Validators.Brazil.validate(:cpf, "000.000.000-00")
+    iex> Bali.Validators.Brazil.validate(:cpf, "000.000.000-00")
     {:ok, "000.000.000-00"}
 
-    iex> Validators.Brazil.validate(:cpf, "0000.000.000-000")
+    iex> Bali.Validators.Brazil.validate(:cpf, "0000.000.000-000")
     {:error, "CPF inválido"}
 
-    iex> Validators.Brazil.validate(:cnpj, "00.000.000/0000-00")
+    iex> Bali.Validators.Brazil.validate(:cnpj, "00.000.000/0000-00")
     {:ok, "00.000.000/0000-00"}
 
-    iex> Validators.Brazil.validate(:cnpj, "00.000.000/0000-000")
+    iex> Bali.Validators.Brazil.validate(:cnpj, "00.000.000/0000-000")
     {:error, "CNPJ inválido"}
 
   ```

--- a/lib/validators/colombia.ex
+++ b/lib/validators/colombia.ex
@@ -1,4 +1,4 @@
-defmodule Validators.Colombia do
+defmodule Bali.Validators.Colombia do
   @moduledoc """
   Validador para los identificadores personales y fiscales de Colombia.
   Soporta la CC (Cédula de Ciudadania), la CE (Cédula de Extranjería) y 
@@ -12,22 +12,22 @@ defmodule Validators.Colombia do
 
   ```elixir
 
-    iex> Validators.Colombia.validate(:cc, "1234567891")
+    iex> Bali.Validators.Colombia.validate(:cc, "1234567891")
     {:ok, "1234567891"}
 
-    iex> Validators.Colombia.validate(:cc, "12345678912")
+    iex> Bali.Validators.Colombia.validate(:cc, "12345678912")
     {:error, "CC inválida"}
 
-    iex> Validators.Colombia.validate(:ce, "123456")
+    iex> Bali.Validators.Colombia.validate(:ce, "123456")
     {:ok, "123456"}
 
-    iex> Validators.Colombia.validate(:ce, "1234567")
+    iex> Bali.Validators.Colombia.validate(:ce, "1234567")
     {:error, "CE inválida"}    
 
-    iex> Validators.Colombia.validate(:nit, "123456-1")
+    iex> Bali.Validators.Colombia.validate(:nit, "123456-1")
     {:ok, "123456-1"}
 
-    iex> Validators.Colombia.validate(:nit, "123456-12")
+    iex> Bali.Validators.Colombia.validate(:nit, "123456-12")
     {:error, "NIT inválido"}    
 
   ```      

--- a/lib/validators/italy.ex
+++ b/lib/validators/italy.ex
@@ -1,4 +1,4 @@
-defmodule Validators.Italy do
+defmodule Bali.Validators.Italy do
   @moduledoc """
   Validador para los identificadores personales y fiscales de Italia.
   Soporta el NIF (Número de identificación fiscal)
@@ -12,16 +12,16 @@ defmodule Validators.Italy do
 
   ```elixir
 
-    iex> Validators.Italy.validate(:nif, "VRDGPP13R10B293P")
+    iex> Bali.Validators.Italy.validate(:nif, "VRDGPP13R10B293P")
     {:ok, "VRDGPP13R10B293P"}
 
-    iex> Validators.Italy.validate(:nif, "VRDGPP13R10B29BP")
+    iex> Bali.Validators.Italy.validate(:nif, "VRDGPP13R10B29BP")
     {:error, "NIF inválido"}
 
-    iex> Validators.Italy.validate(:cie, "CA00000AA")
+    iex> Bali.Validators.Italy.validate(:cie, "CA00000AA")
     {:ok, "CA00000AA"}
 
-    iex> Validators.Italy.validate(:cie, "BA00000AA")
+    iex> Bali.Validators.Italy.validate(:cie, "BA00000AA")
     {:error, "CIE inválido"}
 
   ```

--- a/lib/validators/mexico.ex
+++ b/lib/validators/mexico.ex
@@ -1,4 +1,4 @@
-defmodule Validators.Mexico do
+defmodule Bali.Validators.Mexico do
   @moduledoc """
   Validador para los identificadores personales y fiscales de Mexico.
   Soporta el RFC (Registro Federal de Contribuyentes) y el 
@@ -12,16 +12,16 @@ defmodule Validators.Mexico do
 
   ```elixir
 
-    iex> Validators.Mexico.validate(:curp, "ROCE000131HNLDNDA0")
+    iex> Bali.Validators.Mexico.validate(:curp, "ROCE000131HNLDNDA0")
     {:ok, "ROCE000131HNLDNDA0"}
 
-    iex> Validators.Mexico.validate(:curp, "BADD110313HCMLNS0Q")
+    iex> Bali.Validators.Mexico.validate(:curp, "BADD110313HCMLNS0Q")
     {:error, "CURP inválido"}
 
-    iex> Validators.Mexico.validate(:rfc, "AAFI7906296J1")
+    iex> Bali.Validators.Mexico.validate(:rfc, "AAFI7906296J1")
     {:ok, "AAFI7906296J1"}
 
-    iex> Validators.Mexico.validate(:rfc, "OIBD890101MQB")
+    iex> Bali.Validators.Mexico.validate(:rfc, "OIBD890101MQB")
     {:error, "RFC inválido"}
 
   ```

--- a/lib/validators/portugal.ex
+++ b/lib/validators/portugal.ex
@@ -1,4 +1,4 @@
-defmodule Validators.Portugal do
+defmodule Bali.Validators.Portugal do
   @moduledoc """
   Validador para los identificadores personales y fiscales de Portugal.
   Soporta el NIF (Número de identificación fiscal)
@@ -13,10 +13,10 @@ defmodule Validators.Portugal do
 
   ```elixir
 
-    iex> Validators.Portugal.validate(:nif, "123456789")
+    iex> Bali.Validators.Portugal.validate(:nif, "123456789")
     {:ok, "123456789"}
 
-    iex> Validators.Portugal.validate(:nif, "12345678")
+    iex> Bali.Validators.Portugal.validate(:nif, "12345678")
     {:error, "NIF inválido"}
 
   ```    

--- a/lib/validators/spain.ex
+++ b/lib/validators/spain.ex
@@ -1,4 +1,4 @@
-defmodule Validators.Spain do
+defmodule Bali.Validators.Spain do
   @moduledoc """
   Validador para los identificadores personales y fiscales de España.
   Soporta el DNI (Documento Nacional de Identidad) y el 
@@ -12,22 +12,22 @@ defmodule Validators.Spain do
 
   ```elixir
 
-    iex> Validators.Spain.validate(:dni, "46324571H")
+    iex> Bali.Validators.Spain.validate(:dni, "46324571H")
     {:ok, "46324571H"}
 
-    iex> Validators.Spain.validate(:dni, "46324571I")
+    iex> Bali.Validators.Spain.validate(:dni, "46324571I")
     {:error, "DNI inválido"}
 
-    iex> Validators.Spain.validate(:nie, "Z1234567R")
+    iex> Bali.Validators.Spain.validate(:nie, "Z1234567R")
     {:ok, "Z1234567R"}
 
-    iex> Validators.Spain.validate(:nie, "Z1234567I")
+    iex> Bali.Validators.Spain.validate(:nie, "Z1234567I")
     {:error, "NIE inválido"}
 
-    iex> Validators.Spain.validate(:nif, "46324571H")
+    iex> Bali.Validators.Spain.validate(:nif, "46324571H")
     {:ok, "46324571H"}
 
-    iex> Validators.Spain.validate(:nif, "46324571I")
+    iex> Bali.Validators.Spain.validate(:nif, "46324571I")
     {:error, "NIF inválido"}    
 
   ```     

--- a/test/validators/brazil_test.exs
+++ b/test/validators/brazil_test.exs
@@ -1,7 +1,7 @@
 defmodule Validators.BrazilTest do
   use ExUnit.Case
 
-  alias Validators.Brazil
+  alias Bali.Validators.Brazil
 
   test "Puedo validar el CPF(Cadastro de Pessoas Físicas) para Brazil" do
     value = "123.456.789-01"

--- a/test/validators/colombia_test.exs
+++ b/test/validators/colombia_test.exs
@@ -1,7 +1,7 @@
 defmodule Validators.ColombiaTest do
   use ExUnit.Case
 
-  alias Validators.Colombia
+  alias Bali.Validators.Colombia
 
   test "Puedo validar que la CC es correcta a 6 dígitos" do
     value = "123456"

--- a/test/validators/italy_test.exs
+++ b/test/validators/italy_test.exs
@@ -1,7 +1,7 @@
 defmodule Validators.ItalyTest do
   use ExUnit.Case
 
-  alias Validators.Italy
+  alias Bali.Validators.Italy
 
   test "Puedo validar el NIF(Número de identificación fiscal) para Italia" do
     value = "VRDGPP13R10B293P"

--- a/test/validators/mexico_test.exs
+++ b/test/validators/mexico_test.exs
@@ -1,7 +1,7 @@
 defmodule Validators.MexicoTest do
   use ExUnit.Case
 
-  alias Validators.Mexico
+  alias Bali.Validators.Mexico
 
   test "Puedo validar que el RFC es correcto" do
     value = "AAFI7906296J1"

--- a/test/validators/portugal_test.exs
+++ b/test/validators/portugal_test.exs
@@ -1,7 +1,7 @@
 defmodule Validators.PortugalTest do
   use ExUnit.Case
 
-  alias Validators.Portugal
+  alias Bali.Validators.Portugal
 
   test "Puedo validar el NIF(Número de identificación fiscal) para Portugal" do
     value = "123456789"

--- a/test/validators/spain_test.exs
+++ b/test/validators/spain_test.exs
@@ -1,7 +1,7 @@
 defmodule Validators.SpainTest do
   use ExUnit.Case
 
-  alias Validators.Spain
+  alias Bali.Validators.Spain
 
   test "Puedo validar que el DNI(Documento Nacional de Identidad) es correcto" do
     value = "46324571H"


### PR DESCRIPTION
All the modules for the different countries where using Bali
prefix(namespace), this may cause conflicts with others libs, because
Validators Prefix is too generic