### PR TITLE
Change Italy fiscal document type

### DIFF
--- a/lib/bali.ex
+++ b/lib/bali.ex
@@ -17,7 +17,7 @@ defmodule Bali do
     mx: ["rfc"],
     co: ["nit"],
     es: ["nif"],
-    it: ["nif"],
+    it: ["cf"],
     pt: ["nif"],
     br: ["cnpj"]
   }
@@ -26,7 +26,7 @@ defmodule Bali do
     mx: ["curp"],
     co: ["cc", "ce"],
     es: ["dni", "nie"],
-    it: ["cie"],
+    it: ["cie", "cf"],
     pt: ["nif"],
     br: ["cpf"]
   }
@@ -84,11 +84,11 @@ defmodule Bali do
     {:error, "NIE inválido"}
 
     # Italia
-    iex> Bali.validate(:it, :nif, "VRDGPP13R10B293P")
+    iex> Bali.validate(:it, :cf, "VRDGPP13R10B293P")
     {:ok, "VRDGPP13R10B293P"}
 
-    iex> Bali.validate(:it, :nif, "VRDGPP13R10B29BP")
-    {:error, "NIF inválido"}
+    iex> Bali.validate(:it, :cf, "VRDGPP13R10B29BP")
+    {:error, "CF inválido"}
 
     # Portugal
     iex> Bali.validate(:pt, :nif, "123456789")

--- a/lib/validators/italy.ex
+++ b/lib/validators/italy.ex
@@ -1,22 +1,22 @@
 defmodule Bali.Validators.Italy do
   @moduledoc """
   Validador para los identificadores personales y fiscales de Italia.
-  Soporta el NIF (Número de identificación fiscal)
+  Soporta el CF (Codice Fiscale)
   Soporta el número de CIE (Carta de Identidad Electrónica)
   """
 
   @doc """
-  Valida el formato del NIF o el número de CIE
+  Valida el formato del CF o el número de CIE
 
   ## Ejemplos:
 
   ```elixir
 
-    iex> Bali.Validators.Italy.validate(:nif, "VRDGPP13R10B293P")
+    iex> Bali.Validators.Italy.validate(:cf, "VRDGPP13R10B293P")
     {:ok, "VRDGPP13R10B293P"}
 
-    iex> Bali.Validators.Italy.validate(:nif, "VRDGPP13R10B29BP")
-    {:error, "NIF inválido"}
+    iex> Bali.Validators.Italy.validate(:cf, "VRDGPP13R10B29BP")
+    {:error, "CF inválido"}
 
     iex> Bali.Validators.Italy.validate(:cie, "CA00000AA")
     {:ok, "CA00000AA"}
@@ -27,11 +27,11 @@ defmodule Bali.Validators.Italy do
   ```
   """
   @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def validate(:nif, value) do
-    if Regex.match?(nif(), value) do
+  def validate(:cf, value) do
+    if Regex.match?(cf(), value) do
       {:ok, value}
     else
-      {:error, "NIF inválido"}
+      {:error, "CF inválido"}
     end
   end
 
@@ -55,7 +55,7 @@ defmodule Bali.Validators.Italy do
     ~r/^C[A-Z]\d{5}[A-Z]{2}$/
   end
 
-  # Expresión regular para validar el NIF
+  # Expresión regular para validar el CF
   # Su estructura es la siguiente:
   #   - Se utilizan las tres primeras consonantes del apellido
   #   - Se utilizan las tres primeras consonantes del nombre
@@ -64,8 +64,8 @@ defmodule Bali.Validators.Italy do
   #   - Cumpleaños y sexo (2 dígitos)
   #   - Ciudad de nacimiento (4 caracteres alfanuméricos)
   #   - Caracter de control (una letra)
-  @spec nif() :: Regex.t()
-  defp nif do
+  @spec cf() :: Regex.t()
+  defp cf do
     ~r/^([A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST]{1}[0-9LMNPQRSTUV]{2}[A-Z]{1}[0-9LMNPQRSTUV]{3}[A-Z]{1})$|([0-9]{11})$/
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bali.MixProject do
   def project do
     [
       app: :bali,
-      version: "0.2.1",
+      version: "0.3.0",
       description: "Validate personal and tax identifiers for mx, co, es, pt, it, br",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,

--- a/test/bali_test.exs
+++ b/test/bali_test.exs
@@ -102,14 +102,14 @@ defmodule BaliTest do
     assert {:error, "CURP inválido"} == Bali.validate(:mx, :curp, value)
   end
 
-  test "Puedo validar el identificador NIF(Numero de identificacion fiscal) de Italia exitosamente" do
+  test "Puedo validar el identificador CF(Codice Fiscale) de Italia exitosamente" do
     value = "VRDGPP13R10B293P"
-    assert {:ok, value} == Bali.validate(:it, :nif, value)
+    assert {:ok, value} == Bali.validate(:it, :cf, value)
   end
 
-  test "Puedo verificar que el identificador NIF(Numero de identificacion fiscal) de Italia no es correcto" do
+  test "Puedo verificar que el identificador CF(Codice Fiscale) de Italia no es correcto" do
     value = "VRDGPP13R10B29BP"
-    assert {:error, "NIF inválido"} == Bali.validate(:it, :nif, value)
+    assert {:error, "CF inválido"} == Bali.validate(:it, :cf, value)
   end
 
   test "Puedo validar el número de la CIE(Carta de Identidad Electrónica) para Italia exitosamente" do
@@ -174,14 +174,14 @@ defmodule BaliTest do
              Bali.validate_fiscal_document(:es, :invalid_nif, "46324571H")
   end
 
-  test "Puedo validar que el documento fiscal para Italia(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do
+  test "Puedo validar que el documento fiscal para Italia(cf) pertenece al conjunto de documentos válidos y su valor es correcto" do
     assert {:ok, "VRDGPP13R10B293P"} ==
-             Bali.validate_fiscal_document(:it, :nif, "VRDGPP13R10B293P")
+             Bali.validate_fiscal_document(:it, :cf, "VRDGPP13R10B293P")
   end
 
-  test "Puedo validar que el documento fiscal para Italia(invalid_nif) no pertenece al conjunto de documentos válidos" do
+  test "Puedo validar que el documento fiscal para Italia(invalid_cf) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento fiscal inválido para el país: it"} ==
-             Bali.validate_fiscal_document(:it, :invalid_nif, "VRDGPP13R10B293P")
+             Bali.validate_fiscal_document(:it, :invalid_cf, "VRDGPP13R10B293P")
   end
 
   test "Puedo validar que el documento fiscal para Brasil(cnpj) pertenece al conjunto de documentos válidos y su valor es correcto" do

--- a/test/validators/italy_test.exs
+++ b/test/validators/italy_test.exs
@@ -3,14 +3,14 @@ defmodule Validators.ItalyTest do
 
   alias Bali.Validators.Italy
 
-  test "Puedo validar el NIF(Número de identificación fiscal) para Italia" do
+  test "Puedo validar el CF(Codide Fiscale) para Italia" do
     value = "VRDGPP13R10B293P"
-    assert {:ok, value} == Italy.validate(:nif, value)
+    assert {:ok, value} == Italy.validate(:cf, value)
   end
 
-  test "Puedo validar que el NIF(Número de identificación fiscal) para Italia no es correcto" do
+  test "Puedo validar que el CF(Codide Fiscale) para Italia no es correcto" do
     value = "VRDGPP13R10B29BP"
-    assert {:error, "NIF inválido"} == Italy.validate(:nif, value)
+    assert {:error, "CF inválido"} == Italy.validate(:cf, value)
   end
 
   test "Puedo validar el número de la CIE(Carta de Identidad Electrónica) para Italia" do


### PR DESCRIPTION
Fiscal document is CF(Codice Fiscale), this document is like a US SSN
so every person in Italy has it and it can be used as a personal
identification as well