### PR TITLE
Validator Base Module

### DIFF
--- a/lib/bali/validator.ex
+++ b/lib/bali/validator.ex
@@ -1,0 +1,23 @@
+defmodule Bali.Validator do
+  defmacro __using__(opts) do
+    quote do
+      uq_opts = unquote(opts)
+      @valid_docs Keyword.get(uq_opts, :documents, [])
+      @country Keyword.get(uq_opts, :country, "")
+
+      def validate(document_type, value) do
+        case Map.get(@valid_docs, document_type) do
+          nil ->
+            {:error, "Invalid document for country #{@country}"}
+
+          regex ->
+            if Regex.match?(regex, value) do
+              true
+            else
+              {:error, "Invalid value for #{document_type}"}
+            end
+        end
+      end
+    end
+  end
+end

--- a/lib/validators/portugal.ex
+++ b/lib/validators/portugal.ex
@@ -1,44 +1,17 @@
 defmodule Bali.Validators.Portugal do
   @moduledoc """
-  Validador para los identificadores personales y fiscales de Portugal.
-  Soporta el NIF (Número de identificación fiscal)
+  Validator for Portuguese personal and tax identifications.any()
+
+  ## Supported documents:
+
+  ### nif - Número de Identificação Fiscal
+  Tax identification number
+
   """
 
-  @doc """
-  Valida el formato del NIF
-  Este identificador se utiliza tanto para documentos personales 
-  como fiscales, segun lo revisado con operaciones
-    
-  ## Ejemplos:
-
-  ```elixir
-
-    iex> Bali.Validators.Portugal.validate(:nif, "123456789")
-    {:ok, "123456789"}
-
-    iex> Bali.Validators.Portugal.validate(:nif, "12345678")
-    {:error, "NIF inválido"}
-
-  ```    
-  """
-  @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  def validate(:nif, value) do
-    if Regex.match?(nif(), value) do
-      {:ok, value}
-    else
-      {:error, "NIF inválido"}
-    end
-  end
-
-  def validate(_, _) do
-    {:error, "Tipo de documento inválido"}
-  end
-
-  # Expresión regular para validar el NIF
-  # Su estructura es un bloque de nueve dígitos:
-  # ejemplo '999999999'
-  @spec nif() :: Regex.t()
-  defp nif do
-    ~r/^\d{9}$/
-  end
+  use Bali.Validator,
+    country: :pt,
+    documents: %{
+      nif: ~r/^\d{9}$/
+    }
 end


### PR DESCRIPTION
## Context

Instead of having to create a function for each different document we need for every country, we added a base module that creates this function for each specified document in the `use` command.

### Example

```elixir
  use Bali.Validator,
    country: :pt,
    documents: %{
      nif: ~r/^\d{9}$/
    }

```