### PR TITLE
Support for 7 digit as valid CE

### DIFF
--- a/lib/bali.ex
+++ b/lib/bali.ex
@@ -61,7 +61,7 @@ defmodule Bali do
     iex> Bali.validate(:co, :ce, "123456")
     {:ok, "123456"}
 
-    iex> Bali.validate(:co, :ce, "1234567")
+    iex> Bali.validate(:co, :ce, "12345678")
     {:error, "CE inválida"}
 
     iex> Bali.validate(:co, :nit, "123456-1")

--- a/lib/validators/colombia.ex
+++ b/lib/validators/colombia.ex
@@ -83,7 +83,7 @@ defmodule Bali.Validators.Colombia do
   # Su estructura es un bloque de 6 dígitos
   @spec ce() :: Regex.t()
   defp ce do
-    ~r/^\d{6}$/
+    ~r/^\d{6,7}$/
   end
 
   # Expresión regular para validar una NIT

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Bali.MixProject do
   def project do
     [
       app: :bali,
-      version: "0.4.0",
+      version: "0.4.1",
       description: "Validate personal and tax identifiers for mx, co, es, pt, it, br",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,

--- a/test/bali_test.exs
+++ b/test/bali_test.exs
@@ -68,7 +68,7 @@ defmodule BaliTest do
   end
 
   test "Puedo validar que el identificador CE(Cédula de Extranjería) de Colombia no es correcto" do
-    value = "1234567"
+    value = "12345678"
     assert {:error, "CE inválida"} == Bali.validate(:co, :ce, value)
   end
 

--- a/test/validators/colombia_test.exs
+++ b/test/validators/colombia_test.exs
@@ -38,8 +38,13 @@ defmodule Validators.ColombiaTest do
     assert {:ok, value} == Colombia.validate(:ce, value)
   end
 
-  test "Puedo verificar que la CE es inválida a 7 dígitos" do
+   test "Puedo validar que la CE es correcta a 7 dígitos" do
     value = "1234567"
+    assert {:ok, value} == Colombia.validate(:ce, value)
+  end
+
+  test "Puedo verificar que la CE es inválida a 8 dígitos" do
+    value = "12345678"
     assert {:error, "CE inválida"} == Colombia.validate(:ce, value)
   end
 

--- a/test/validators/colombia_test.exs
+++ b/test/validators/colombia_test.exs
@@ -38,7 +38,7 @@ defmodule Validators.ColombiaTest do
     assert {:ok, value} == Colombia.validate(:ce, value)
   end
 
-   test "Puedo validar que la CE es correcta a 7 dígitos" do
+  test "Puedo validar que la CE es correcta a 7 dígitos" do
     value = "1234567"
     assert {:ok, value} == Colombia.validate(:ce, value)
   end


### PR DESCRIPTION
Legally we have no restriction on the length of the immigration ID number. At the moment it is only required to validate that it has 6 or 7 digits