### PR TITLE
Add cc as personal document type for PT

### DIFF
--- a/lib/bali.ex
+++ b/lib/bali.ex
@@ -27,7 +27,7 @@ defmodule Bali do
     co: ["cc", "ce", "passport", "password"],
     es: ["dni", "nie"],
     it: ["cie", "cf"],
-    pt: ["cc"],
+    pt: ["nif", "cc"],
     br: ["cpf"]
   }
 
@@ -96,6 +96,12 @@ defmodule Bali do
 
     iex> Bali.validate(:pt, :nif, "12345678")
     {:error, "NIF inválido"}
+
+    iex> Bali.validate(:pt, :cc, "12345678")
+    {:ok, "12345678"}
+
+    iex> Bali.validate(:pt, :cc, "1234567")
+    {:error, "CC inválido"}
 
     # Brasil
     iex> Bali.validate(:br, :cpf, "000.000.000-00")

--- a/lib/bali.ex
+++ b/lib/bali.ex
@@ -27,7 +27,7 @@ defmodule Bali do
     co: ["cc", "ce", "passport", "password"],
     es: ["dni", "nie"],
     it: ["cie", "cf"],
-    pt: ["nif"],
+    pt: ["cc"],
     br: ["cpf"]
   }
 

--- a/lib/validators/portugal.ex
+++ b/lib/validators/portugal.ex
@@ -1,14 +1,13 @@
 defmodule Bali.Validators.Portugal do
   @moduledoc """
   Validador para los identificadores personales y fiscales de Portugal.
-  Soporta el NIF (Número de identificación fiscal)
+  Soporta el NIF (Número de identificación fiscal) y
+  Tarjeta de ciudadano (Cartão de cidadão)
   """
 
   @doc """
-  Valida el formato del NIF
-  Este identificador se utiliza tanto para documentos personales 
-  como fiscales, segun lo revisado con operaciones
-    
+  Valida el formato del NIF o de CC
+
   ## Ejemplos:
 
   ```elixir
@@ -19,7 +18,13 @@ defmodule Bali.Validators.Portugal do
     iex> Bali.Validators.Portugal.validate(:nif, "12345678")
     {:error, "NIF inválido"}
 
-  ```    
+    iex> Bali.Validators.Portugal.validate(:cc, "12345678")
+    {:ok, "12345678"}
+
+    iex> Bali.Validators.Portugal.validate(:cc, "1234567")
+    {:error, "CC inválido"}
+
+  ```
   """
   @spec validate(atom, String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def validate(:nif, value) do
@@ -27,6 +32,14 @@ defmodule Bali.Validators.Portugal do
       {:ok, value}
     else
       {:error, "NIF inválido"}
+    end
+  end
+
+  def validate(:cc, value) do
+    if Regex.match?(cc(), value) do
+      {:ok, value}
+    else
+      {:error, "CC inválido"}
     end
   end
 
@@ -40,5 +53,13 @@ defmodule Bali.Validators.Portugal do
   @spec nif() :: Regex.t()
   defp nif do
     ~r/^\d{9}$/
+  end
+
+  # Expresión regular para validar la CC
+  # Su estructura es un bloque de ocho dígitos:
+  # ejemplo '88888888'
+  @spec cc() :: Regex.t()
+  defp cc do
+    ~r/^\d{8}$/
   end
 end

--- a/test/bali_test.exs
+++ b/test/bali_test.exs
@@ -290,4 +290,13 @@ defmodule BaliTest do
     assert {:error, "Documento personal inválido para el país: pt"} ==
              Bali.validate_personal_document(:pt, :invalid_cc, "123456789")
   end
+
+  test "Puedo validar que el documento personal para Portugal(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "123456789"} == Bali.validate_personal_document(:pt, :nif, "123456789")
+  end
+
+  test "Puedo validar que el documento personal para Portugal(invalid_nif) no pertenece al conjunto de documentos válidos" do
+    assert {:error, "Documento personal inválido para el país: pt"} ==
+             Bali.validate_personal_document(:pt, :invalid_nif, "123456789")
+  end
 end

--- a/test/bali_test.exs
+++ b/test/bali_test.exs
@@ -17,6 +17,21 @@ defmodule BaliTest do
     assert {:error, "NIF inválido"} == Bali.validate(:pt, :nif, value)
   end
 
+  test "Puedo validar el identificador CC(Cartão de cidadão) de Portugal exitosamente" do
+    value = "12345678"
+    assert {:ok, value} == Bali.validate(:pt, :cc, value)
+  end
+
+  test "Puedo validar el identificador CC(Cartão de cidadão) de Portugal exitosamente aunque venga con espacios" do
+    value = "123 456 78"
+    assert {:ok, "12345678"} == Bali.validate(:pt, :cc, value)
+  end
+
+  test "Puedo validar que el identificador CC(Cartão de cidadão) de Portugal no es correcto" do
+    value = "1234567"
+    assert {:error, "CC inválido"} == Bali.validate(:pt, :cc, value)
+  end
+
   test "Puedo validar el identificador DNI(Documento Nacional de Identidad) de España exitosamente" do
     value = "46324571H"
     assert {:ok, value} == Bali.validate(:es, :dni, value)
@@ -267,12 +282,12 @@ defmodule BaliTest do
              Bali.validate_personal_document(:br, :invalid_cpf, "123.456.789-01")
   end
 
-  test "Puedo validar que el documento personal para Portugal(nif) pertenece al conjunto de documentos válidos y su valor es correcto" do
-    assert {:ok, "123456789"} == Bali.validate_personal_document(:pt, :nif, "123456789")
+  test "Puedo validar que el documento personal para Portugal(cc) pertenece al conjunto de documentos válidos y su valor es correcto" do
+    assert {:ok, "12345678"} == Bali.validate_personal_document(:pt, :cc, "12345678")
   end
 
-  test "Puedo validar que el documento personal para Portugal(invalid_nif) no pertenece al conjunto de documentos válidos" do
+  test "Puedo validar que el documento personal para Portugal(invalid_cc) no pertenece al conjunto de documentos válidos" do
     assert {:error, "Documento personal inválido para el país: pt"} ==
-             Bali.validate_personal_document(:pt, :invalid_nif, "123456789")
+             Bali.validate_personal_document(:pt, :invalid_cc, "123456789")
   end
 end


### PR DESCRIPTION
### Context
Currently, `nif` is used as tax document type and as personal document type. This has changed, so `cc` (Cartão de cidadão) must be added as personal document type and `nif` is only accepted as tax document type.

Added a function to validate the `cc` value as a new personal document type. The `cc` value can only be 8 digits long.
